### PR TITLE
FO-2017 Legger til polyfills

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -785,6 +785,22 @@
         "regexpu-core": "^4.1.3"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.2.5",
+      "resolved": "https://repo.adeo.no/repository/npm-public/@babel/polyfill/-/polyfill-7.2.5.tgz",
+      "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
+      "requires": {
+        "core-js": "^2.5.7",
+        "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://repo.adeo.no/repository/npm-public/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
+    },
     "@babel/preset-env": {
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.4.tgz",
@@ -2137,16 +2153,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
-    },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
-      }
     },
     "babel-preset-jest": {
       "version": "23.2.0",
@@ -12358,9 +12364,9 @@
       }
     },
     "react-app-polyfill": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-0.2.1.tgz",
-      "integrity": "sha512-rcpR+WKmLOoYGDAxXaLlxl5Sw6jqbcD1qg2Okn1Ta2RHCxLuQv75B9Em2L2GvuOTx3lAxDpNl/TYGWbKnO/Aag==",
+      "version": "0.2.2",
+      "resolved": "https://repo.adeo.no/repository/npm-public/react-app-polyfill/-/react-app-polyfill-0.2.2.tgz",
+      "integrity": "sha512-mAYn96B/nB6kWG87Ry70F4D4rsycU43VYTj3ZCbKP+SLJXwC0x6YCbwcICh3uW8/C9s1VgP197yx+w7SCWeDdQ==",
       "requires": {
         "core-js": "2.6.4",
         "object-assign": "4.1.1",
@@ -12371,12 +12377,12 @@
       "dependencies": {
         "core-js": {
           "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/core-js/-/core-js-2.6.4.tgz",
           "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A=="
         },
         "promise": {
           "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.2.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/promise/-/promise-8.0.2.tgz",
           "integrity": "sha512-EIyzM39FpVOMbqgzEHhxdrEhtOSDOtjMZQ0M6iVfCE+kWNgCkAyOdnuCWqfmflylftfadU6FkiMgHZA2kUzwRw==",
           "requires": {
             "asap": "~2.0.6"
@@ -13293,11 +13299,6 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "regenerator-transform": {
       "version": "0.13.4",
@@ -15732,7 +15733,7 @@
     },
     "whatwg-fetch": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "resolved": "https://repo.adeo.no/repository/npm-public/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
       "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-mimetype": {

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "prettier": "prettier --write --single-quote --tab-width 4 src/**/*.ts src/**/*.tsx src/**/*.less"
   },
   "dependencies": {
+    "@babel/polyfill": "^7.2.5",
     "@craco/craco": "^3.5.0",
     "ajv": "6.10.0",
-    "babel-polyfill": "6.26.0",
     "classnames": "^2.2.6",
-    "gsap": "^2.1.2",
     "craco-less": "^1.6.0",
+    "gsap": "^2.1.2",
     "intl": "1.2.5",
     "intl-locales-supported": "1.0.0",
     "less-plugin-npm-import": "^2.1.0",
@@ -65,7 +65,7 @@
     "prop-types": "^15.7.2",
     "query-string": "5.1.1",
     "react": "^16.8.3",
-    "react-app-polyfill": "^0.2.1",
+    "react-app-polyfill": "^0.2.2",
     "react-collapse": "^4.0.3",
     "react-day-picker": "^7.3.0",
     "react-dom": "16.8.3",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
-import 'babel-polyfill';
+import '@babel/polyfill';
+import 'react-app-polyfill/ie11';
 import './polyfills/polyfill';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';


### PR DESCRIPTION
I versjon 1.x.x av react-scripts ble dette inkludert automatisk, men i
versjon 2.x.x må man eksplisitt inkludere react-app-polyfill. Den
oppgraderingen gikk litt under radaren ettersom det var craco som var i
fokus.