### PR TITLE
Legger til klassifisering av POA gruppe (patch)

### DIFF
--- a/src/innhold/innhold-logikk-niva4.tsx
+++ b/src/innhold/innhold-logikk-niva4.tsx
@@ -13,13 +13,14 @@ import {
     selectOpprettetRegistreringDato,
     selectDinSituasjonSvar
 } from '../ducks/brukerregistrering';
-import { seVeientilarbeid, seIARBSPlaster } from '../metrics/metrics';
+import { seVeientilarbeid, seIARBSPlaster, tellPoaGruppe } from '../metrics/metrics';
 import { hotjarTrigger } from '../hotjar';
 import './innhold.less';
 import InnholdView from './innhold-view';
 import { MotestotteContext } from '../ducks/motestotte';
 import { SituasjonContext } from '../ducks/situasjon';
 import { Formidlingsgruppe, OppfolgingContext, Servicegruppe } from '../ducks/oppfolging';
+import getPoaGroup from '../utils/get-poa-group'
 // import { RegistreringType } from '../ducks/bruker-info'
 
 const LANSERINGSDATO_EGENVURDERING = new Date(2019, 4, 10);
@@ -51,13 +52,16 @@ const InnholdLogikkNiva4 = ({harEgenvurderingbesvarelse, egenvurderingbesvarelse
     const { erSykmeldtMedArbeidsgiver, registreringType, rettighetsgruppe } = brukerinfoData;
     const skalViseIARBSPlaster = false // formidlingsgruppe === Formidlingsgruppe.IARBS && registreringType === RegistreringType.ALLEREDE_REGISTRERT && rettighetsgruppe !== 'AAP';
     const registreringTypeOrIngenVerdi = registreringType ? registreringType : 'INGEN_VERDI';
+    const foreslattInnsatsgruppeOrIngenVerdi = foreslattInnsatsgruppe ? foreslattInnsatsgruppe : 'INGEN_VERDI'
     const fremtidigSvarOrIngenVerdi = fremtidigSvar ? fremtidigSvar : 'INGEN_VERDI';
+    const formidlingsgruppeOrIngenVerdi = formidlingsgruppe ? formidlingsgruppe : 'INGEN_VERDI';
     const motestotteToggle = featureToggleData ? featureToggleData['veientilarbeid.motestotte.lansert'] : false;
     const permittertToggle = featureToggleData ? featureToggleData['veientilarbeid.permittert.ny-dialog'] : false;
     const endreSituasjonToggle = featureToggleData ? featureToggleData['veientilarbeid.permittert.situasjon.endre'] : false;
 
     const erPermittert = dinSituasjon === 'ER_PERMITTERT' && permittertToggle === true
     const erPermittertEllerEndret = endreSituasjonToggle && (erPermittert || SituasjonData !== null)
+    const POAGruppe = getPoaGroup({ dinSituasjon, formidlingsgruppe: formidlingsgruppeOrIngenVerdi, innsatsgruppe: foreslattInnsatsgruppeOrIngenVerdi });
 
     React.useEffect(() => {
         seVeientilarbeid(
@@ -73,7 +77,8 @@ const InnholdLogikkNiva4 = ({harEgenvurderingbesvarelse, egenvurderingbesvarelse
             reservasjonKRRJaNei
     );
         hotjarTrigger(erMikrofrontend());
-        seIARBSPlaster(skalViseIARBSPlaster, formidlingsgruppe, servicegruppe, rettighetsgruppe)
+        seIARBSPlaster(skalViseIARBSPlaster, formidlingsgruppe, servicegruppe, rettighetsgruppe);
+        tellPoaGruppe(POAGruppe);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 

--- a/src/metrics/metrics.ts
+++ b/src/metrics/metrics.ts
@@ -189,3 +189,7 @@ interface KrrMetrikkData extends StandardMetrikkData {
 export const klikkPaDifiLenke = (metrikker: KrrMetrikkData) => {
     uniLogger('krr.difi.click', metrikker);
 };
+
+export const tellPoaGruppe = (gruppe: string) => {
+    uniLogger('poagruppe', { gruppe: gruppe });
+};

--- a/src/utils/get-poa-group.test.ts
+++ b/src/utils/get-poa-group.test.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import getPoaGroup from './get-poa-group';
+
+describe('getPoaGroup returnerer forventede verdier', () => {
+  it('returnerer kss for standard, mistet jobben og arbs', () => {
+    const data = {
+      dinSituasjon: 'MISTET_JOBBEN',
+      innsatsgruppe: 'STANDARD_INNSATS',
+      formidlingsgruppe: 'ARBS'
+    };
+    expect(getPoaGroup(data)).to.equal('kss');
+  });
+  it('returnerer boo for standard, mistet jobben og iarbs', () => {
+    const data = {
+      dinSituasjon: 'MISTET_JOBBEN',
+      innsatsgruppe: 'STANDARD_INNSATS',
+      formidlingsgruppe: 'IARBS'
+    };
+    expect(getPoaGroup(data)).to.equal('boo');
+  });
+});

--- a/src/utils/get-poa-group.ts
+++ b/src/utils/get-poa-group.ts
@@ -1,0 +1,17 @@
+interface Data {
+  dinSituasjon: string;
+  innsatsgruppe: string;
+  formidlingsgruppe: string;
+}
+
+const getPoaGroup = (data: Data): string => {
+  const { dinSituasjon, innsatsgruppe, formidlingsgruppe } = data;
+  const kriterier = [];
+  kriterier.push(dinSituasjon === 'MISTET_JOBBEN' ? 'kss' : 'boo');
+  kriterier.push(innsatsgruppe === 'STANDARD_INNSATS' ? 'kss' : 'boo');
+  kriterier.push(formidlingsgruppe === 'IARBS' ? 'kss' : 'boo');
+  const isKSS = !kriterier.includes('boo');
+  return isKSS ? 'kss' : 'boo';
+};
+
+export default getPoaGroup;

--- a/src/utils/get-poa-group.ts
+++ b/src/utils/get-poa-group.ts
@@ -9,7 +9,7 @@ const getPoaGroup = (data: Data): string => {
   const kriterier = [];
   kriterier.push(dinSituasjon === 'MISTET_JOBBEN' ? 'kss' : 'boo');
   kriterier.push(innsatsgruppe === 'STANDARD_INNSATS' ? 'kss' : 'boo');
-  kriterier.push(formidlingsgruppe === 'IARBS' ? 'kss' : 'boo');
+  kriterier.push(formidlingsgruppe === 'ARBS' ? 'kss' : 'boo');
   const isKSS = !kriterier.includes('boo');
   return isKSS ? 'kss' : 'boo';
 };


### PR DESCRIPTION
Starten på å klassifisere bruker til kss (klare-seg-selv) eller boo (bistand og oppfølging).
Veldig lavterskel og smalt i starten. Kun for Amplitudebruk.

Kriterier for kss:
- MISTET_JOBBEN
- ARBS
- STANDARD_INNSATSGRUPPE