### PR TITLE
Tar hensyn til servicegruppe ved gruppering

### DIFF
--- a/src/innhold/innhold-logikk-niva4.tsx
+++ b/src/innhold/innhold-logikk-niva4.tsx
@@ -55,12 +55,19 @@ const InnholdLogikkNiva4 = ({harEgenvurderingbesvarelse, egenvurderingbesvarelse
     const foreslattInnsatsgruppeOrIngenVerdi = foreslattInnsatsgruppe ? foreslattInnsatsgruppe : 'INGEN_VERDI'
     const fremtidigSvarOrIngenVerdi = fremtidigSvar ? fremtidigSvar : 'INGEN_VERDI';
     const formidlingsgruppeOrIngenVerdi = formidlingsgruppe ? formidlingsgruppe : 'INGEN_VERDI';
+    const servicegruppeOrIVURD = servicegruppe ? servicegruppe : 'IVURD';
     const permittertToggle = featureToggleData ? featureToggleData['veientilarbeid.permittert.ny-dialog'] : false;
     const endreSituasjonToggle = featureToggleData ? featureToggleData['veientilarbeid.permittert.situasjon.endre'] : false;
 
     const erPermittert = dinSituasjon === 'ER_PERMITTERT' && permittertToggle === true
     const erPermittertEllerEndret = endreSituasjonToggle && (erPermittert || SituasjonData !== null)
-    const POAGruppe = getPoaGroup({ dinSituasjon, formidlingsgruppe: formidlingsgruppeOrIngenVerdi, innsatsgruppe: foreslattInnsatsgruppeOrIngenVerdi, alder, opprettetRegistreringDato });
+    const POAGruppe = getPoaGroup({
+        dinSituasjon,
+        formidlingsgruppe: formidlingsgruppeOrIngenVerdi,
+        innsatsgruppe: foreslattInnsatsgruppeOrIngenVerdi,
+        alder,
+        servicegruppe: servicegruppeOrIVURD,
+        opprettetRegistreringDato });
 
     React.useEffect(() => {
         seVeientilarbeid(

--- a/src/utils/get-poa-group.test.ts
+++ b/src/utils/get-poa-group.test.ts
@@ -2,12 +2,25 @@ import { expect } from 'chai';
 import getPoaGroup from './get-poa-group';
 
 describe('getPoaGroup returnerer forventede verdier', () => {
-  it('returnerer kss for standard, mistet jobben, arbs, rett alder og under 16 uker', () => {
+  it('returnerer kss for standard, IVURD, mistet jobben, arbs, rett alder og under 16 uker', () => {
     const data = {
       dinSituasjon: 'MISTET_JOBBEN',
       innsatsgruppe: 'STANDARD_INNSATS',
       formidlingsgruppe: 'ARBS',
       alder: 32,
+      servicegruppe: 'IVURD',
+      opprettetRegistreringDato: new Date()
+    };
+    expect(getPoaGroup(data)).to.equal('kss');
+  });
+
+  it('returnerer kss for situasjonsbestemt, IKVAL, mistet jobben, arbs, rett alder og under 16 uker', () => {
+    const data = {
+      dinSituasjon: 'MISTET_JOBBEN',
+      innsatsgruppe: 'SITUASJONSBESTEMT_INNSATS',
+      formidlingsgruppe: 'ARBS',
+      alder: 32,
+      servicegruppe: 'IKVAL',
       opprettetRegistreringDato: new Date()
     };
     expect(getPoaGroup(data)).to.equal('kss');
@@ -19,6 +32,7 @@ describe('getPoaGroup returnerer forventede verdier', () => {
       innsatsgruppe: 'STANDARD_INNSATS',
       formidlingsgruppe: 'ARBS',
       alder: 32,
+      servicegruppe: 'IVURD',
       opprettetRegistreringDato: new Date('2020-01-13')
     };
     expect(getPoaGroup(data)).to.equal('boo');
@@ -30,6 +44,7 @@ describe('getPoaGroup returnerer forventede verdier', () => {
       innsatsgruppe: 'STANDARD_INNSATS',
       formidlingsgruppe: 'ARBS',
       alder: 32,
+      servicegruppe: 'IVURD',
       opprettetRegistreringDato: null
     };
     expect(getPoaGroup(data)).to.equal('boo');
@@ -41,6 +56,7 @@ describe('getPoaGroup returnerer forventede verdier', () => {
       innsatsgruppe: 'STANDARD_INNSATS',
       formidlingsgruppe: 'ARBS',
       alder: 29,
+      servicegruppe: 'IVURD',
       opprettetRegistreringDato: new Date()
     };
     expect(getPoaGroup(data)).to.equal('boo');
@@ -52,6 +68,7 @@ describe('getPoaGroup returnerer forventede verdier', () => {
       innsatsgruppe: 'STANDARD_INNSATS',
       formidlingsgruppe: 'ARBS',
       alder: 56,
+      servicegruppe: 'IVURD',
       opprettetRegistreringDato: new Date()
     };
     expect(getPoaGroup(data)).to.equal('boo');
@@ -63,6 +80,7 @@ describe('getPoaGroup returnerer forventede verdier', () => {
       innsatsgruppe: 'STANDARD_INNSATS',
       formidlingsgruppe: 'IARBS',
       alder: 32,
+      servicegruppe: 'IVURD',
       opprettetRegistreringDato: new Date()
     };
     expect(getPoaGroup(data)).to.equal('boo');

--- a/src/utils/get-poa-group.ts
+++ b/src/utils/get-poa-group.ts
@@ -6,6 +6,7 @@ interface Data {
   formidlingsgruppe: string;
   alder: number;
   opprettetRegistreringDato: Date|null;
+  servicegruppe: string;
 }
 
 const erInnenfor16uker = (dato: Date|null) => {
@@ -15,14 +16,24 @@ const erInnenfor16uker = (dato: Date|null) => {
   return (iDag - beregningsDato.getTime()) < maksTid;
 };
 
+const isStandard = (innsatsgruppe: string, servicegruppe: string) => {
+  return servicegruppe === 'IKVAL' || (servicegruppe === 'IVURD' && innsatsgruppe === 'STANDARD_INNSATS')
+};
+
 const getPoaGroup = (data: Data): POAGruppe => {
-  const { dinSituasjon, innsatsgruppe, formidlingsgruppe, alder, opprettetRegistreringDato } = data;
+  const { 
+    dinSituasjon,
+    innsatsgruppe,
+    formidlingsgruppe,
+    alder,
+    opprettetRegistreringDato,
+    servicegruppe } = data;
   const lavesteAlder = 30;
   const hoyesteAlder = 55;
   const kssSituasjoner = ['MISTET_JOBBEN']
   const kriterier = [];
   kriterier.push(kssSituasjoner.includes(dinSituasjon) ? 'kss' : 'boo');
-  kriterier.push(innsatsgruppe === 'STANDARD_INNSATS' ? 'kss' : 'boo');
+  kriterier.push(isStandard(innsatsgruppe, servicegruppe) ? 'kss' : 'boo');
   kriterier.push(formidlingsgruppe === 'ARBS' ? 'kss' : 'boo');
   kriterier.push(alder > lavesteAlder && alder < hoyesteAlder ? 'kss' : 'boo')
   kriterier.push(erInnenfor16uker(opprettetRegistreringDato) ? 'kss': 'boo')


### PR DESCRIPTION
Dersom servicegruppe er satt (annet enn IVURD) vi resultatet av den overstyre foreslått innsatsgruppe fra profileringen når man deler i `kss` og `boo` 