### PR TITLE
Refaktorisering: Selvstyrte komponenter

### DIFF
--- a/src/demo/demo-dashboard.tsx
+++ b/src/demo/demo-dashboard.tsx
@@ -43,8 +43,8 @@ import {
     settForeslattInnsatsgruppe,
     settFremtidigSituasjon, settOpprettetDato
 } from './demo-state-brukerregistrering';
-import { InnloggingsNiva } from '../komponenter/hent-initial-data/autentiseringsInfoFetcher';
 import tekster from '../tekster/tekster';
+import {InnloggingsNiva} from "../ducks/autentisering";
 
 interface OpprettetRegistreringDato {
     registrertForLanseringEgenvurdering: string;

--- a/src/demo/demo-state.ts
+++ b/src/demo/demo-state.ts
@@ -1,5 +1,5 @@
 import { JSONObject } from 'yet-another-fetch-mock';
-import { InnloggingsNiva } from '../komponenter/hent-initial-data/autentiseringsInfoFetcher';
+import {InnloggingsNiva} from "../ducks/autentisering";
 
 export enum DemoData {
     SERVICEGRUPPE = 'servicegruppe',

--- a/src/ducks/autentisering.ts
+++ b/src/ducks/autentisering.ts
@@ -1,0 +1,29 @@
+import {DataElement, STATUS} from "./api";
+import React from "react";
+
+export enum InnloggingsNiva {
+    LEVEL_1 = 'Level1',
+    LEVEL_2 = 'Level2',
+    LEVEL_3 = 'Level3',
+    LEVEL_4 = 'Level4',
+    UKJENT = 'Ukjent',
+}
+
+export interface State extends DataElement {
+    data: Data;
+}
+
+export interface Data {
+    securityLevel: InnloggingsNiva;
+    loggedIn: boolean;
+}
+
+export const initialState: State = {
+    data: {
+        securityLevel: InnloggingsNiva.UKJENT,
+        loggedIn: false
+    },
+    status: STATUS.NOT_STARTED
+}
+
+export const AutentiseringContext = React.createContext<State>(initialState);

--- a/src/innhold/innhold-logikk-niva3.tsx
+++ b/src/innhold/innhold-logikk-niva3.tsx
@@ -35,7 +35,6 @@ const InnholdLogikkNiva3 = () => {
             visRessurslenker={true}
             skalViseMotestotteLenke={false}
             skalViseIARBSPlaster={false}
-            skalViseRegistrert={false}
             erPermittert={false}
             erPermittertEllerEndret={false}
             amplitudeAktivitetsData={amplitudeAktivitetsData}

--- a/src/innhold/innhold-logikk-niva4.tsx
+++ b/src/innhold/innhold-logikk-niva4.tsx
@@ -19,7 +19,7 @@ import './innhold.less';
 import InnholdView from './innhold-view';
 import { MotestotteContext } from '../ducks/motestotte';
 import { SituasjonContext } from '../ducks/situasjon';
-import { Formidlingsgruppe, OppfolgingContext, Servicegruppe } from '../ducks/oppfolging';
+import { OppfolgingContext, Servicegruppe } from '../ducks/oppfolging';
 import getPoaGroup from '../utils/get-poa-group'
 import isKSSEksperiment from '../utils/is-kss-eksperiment'
 import isKSSKontroll from '../utils/is-kss-kontroll'
@@ -48,8 +48,7 @@ const InnholdLogikkNiva4 = ({harEgenvurderingbesvarelse, egenvurderingbesvarelse
     const { formidlingsgruppe, servicegruppe, underOppfolging, reservasjonKRR } = oppfolgingData;
     const underOppfolgingJaNei = underOppfolging ? 'ja' : 'nei';
     const reservasjonKRRJaNei = reservasjonKRR ? 'ja' : 'nei';
-    const skalViseRegistrert = formidlingsgruppe === Formidlingsgruppe.ARBS;
-    
+
     const brukerinfoData = React.useContext(BrukerInfoContext).data;
     const { erSykmeldtMedArbeidsgiver, registreringType, rettighetsgruppe, alder, geografiskTilknytning } = brukerinfoData;
     const skalViseIARBSPlaster = false // formidlingsgruppe === Formidlingsgruppe.IARBS && registreringType === RegistreringType.ALLEREDE_REGISTRERT && rettighetsgruppe !== 'AAP';
@@ -174,7 +173,6 @@ const InnholdLogikkNiva4 = ({harEgenvurderingbesvarelse, egenvurderingbesvarelse
             skalViseMotestotteLenke={skalViseMotestotteLenke}
             visRessurslenker={visRessurslenker}
             skalViseIARBSPlaster={skalViseIARBSPlaster}
-            skalViseRegistrert={skalViseRegistrert}
             erPermittert={erPermittert}
             erPermittertEllerEndret={erPermittertEllerEndret}
             amplitudeAktivitetsData={amplitudeAktivitetsData}

--- a/src/innhold/innhold-view.tsx
+++ b/src/innhold/innhold-view.tsx
@@ -27,7 +27,6 @@ interface OwnProps {
     skalViseMotestotteLenke: boolean;
     visRessurslenker: boolean;
     skalViseIARBSPlaster: boolean;
-    skalViseRegistrert: boolean;
     erPermittert: boolean;
     erPermittertEllerEndret: boolean;
     amplitudeAktivitetsData: AmplitudeAktivitetsData;
@@ -50,13 +49,12 @@ const AktivitetDialogMeldekort = ({erSykmeldtMedArbeidsgiver, amplitudeAktivitet
     )
 }
 
-export default ({erSykmeldtMedArbeidsgiver,
+const InnholdView = ({erSykmeldtMedArbeidsgiver,
                     skalViseKrrMelding,
                     skalViseEgenvurderingLenke,
                     skalViseMotestotteLenke,
                     visRessurslenker,
                     skalViseIARBSPlaster,
-                    skalViseRegistrert,
                     erPermittertEllerEndret,
                     amplitudeAktivitetsData}: OwnProps) => {
     return (
@@ -68,7 +66,7 @@ export default ({erSykmeldtMedArbeidsgiver,
                 <ReaktiveringMelding/>
                 {skalViseKrrMelding ? <KrrMelding/> : null}
                 {erPermittertEllerEndret && <Situasjon />}
-                {skalViseRegistrert ? <Registrert amplitudeAktivitetsData={amplitudeAktivitetsData} /> : null }
+                <Registrert amplitudeAktivitetsData={amplitudeAktivitetsData} />
                 {skalViseIARBSPlaster ? <IARBSMelding/> : null}
                 {skalViseEgenvurderingLenke ? <Egenvurdering amplitudeAktivitetsData={amplitudeAktivitetsData} /> : null}
                 {skalViseMotestotteLenke ? <Motestotte erSykmeldtMedArbeidsgiver={erSykmeldtMedArbeidsgiver}/> : null}
@@ -87,3 +85,5 @@ export default ({erSykmeldtMedArbeidsgiver,
         </>
     );
 };
+
+export default InnholdView;

--- a/src/komponenter/hent-initial-data/autentiseringsInfoFetcher.tsx
+++ b/src/komponenter/hent-initial-data/autentiseringsInfoFetcher.tsx
@@ -2,48 +2,24 @@ import * as React from 'react';
 import Innholdslaster from '../innholdslaster/innholdslaster';
 import Feilmelding from '../feilmeldinger/feilmelding';
 import { fetchData } from '../../ducks/api-utils';
-import { DataElement, STATUS } from '../../ducks/api';
 import { contextpathDittNav, erMikrofrontend } from '../../utils/app-state-utils';
 import DataProvider from './data-provider';
 import InnholdLogikkNiva4 from '../../innhold/innhold-logikk-niva4';
 import InnholdLogikkNiva3 from '../../innhold/innhold-logikk-niva3';
 import OppfolgingBrukerregistreringProvider from './oppfolging-brukerregistrering-provider';
 
+import {Data as AutentiseringData, State as AutentiseringState, initialState, InnloggingsNiva, AutentiseringContext} from '../../ducks/autentisering';
+
 export const AUTH_API = '/api/auth';
-
-export enum InnloggingsNiva {
-    LEVEL_1 = 'Level1',
-    LEVEL_2 = 'Level2',
-    LEVEL_3 = 'Level3',
-    LEVEL_4 = 'Level4',
-    UKJENT = 'Ukjent',
-}
-
-const initialState: InnloggingsInfo = {
-    data: {
-        loggedIn: false,
-        securityLevel: InnloggingsNiva.UKJENT,
-    },
-    status: STATUS.NOT_STARTED,
-};
-
-export interface Data {
-    loggedIn: boolean;
-    securityLevel: string;
-}
-
-export interface InnloggingsInfo extends DataElement {
-    data: Data;
-}
 
 const AutentiseringsInfoFetcher = () => {
 
-    const [state, setState] = React.useState<InnloggingsInfo>(initialState);
+    const [state, setState] = React.useState<AutentiseringState>(initialState);
 
     const contextpath = erMikrofrontend() ? contextpathDittNav : '';
 
     React.useEffect(() => {
-        fetchData<InnloggingsInfo, Data>(state, setState, `${contextpath}${AUTH_API}`);
+        fetchData<AutentiseringState, AutentiseringData>(state, setState, `${contextpath}${AUTH_API}`);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -53,14 +29,16 @@ const AutentiseringsInfoFetcher = () => {
             storrelse="XXL"
             avhengigheter={[state]}
         >
-            {state.data.securityLevel === InnloggingsNiva.LEVEL_3
-                ? <InnholdLogikkNiva3/>
-                : <OppfolgingBrukerregistreringProvider>
-                    <DataProvider>
-                        <InnholdLogikkNiva4/>
-                    </DataProvider>
-                </OppfolgingBrukerregistreringProvider>
-            }
+            <AutentiseringContext.Provider value={state}>
+                {state.data.securityLevel === InnloggingsNiva.LEVEL_3
+                    ? <InnholdLogikkNiva3/>
+                    : <OppfolgingBrukerregistreringProvider>
+                        <DataProvider>
+                            <InnholdLogikkNiva4/>
+                        </DataProvider>
+                    </OppfolgingBrukerregistreringProvider>
+                }
+            </AutentiseringContext.Provider>
         </Innholdslaster>
     );
 };

--- a/src/komponenter/registrert/registrert.tsx
+++ b/src/komponenter/registrert/registrert.tsx
@@ -1,20 +1,28 @@
-import React, { useContext, useState } from 'react';
-import { Element } from 'nav-frontend-typografi';
-import { AlertStripeInfo } from 'nav-frontend-alertstriper';
+import React, {useContext, useState} from 'react';
+import {Element} from 'nav-frontend-typografi';
+import {AlertStripeInfo} from 'nav-frontend-alertstriper';
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
-import { BrukerregistreringContext } from '../../ducks/brukerregistrering';
-import { BrukerInfoContext } from '../../ducks/bruker-info';
-import { OppfolgingContext } from '../../ducks/oppfolging';
-import { klikkPaDineOpplysninger, seDineOpplysninger, loggAktivitet } from '../../metrics/metrics';
+import {BrukerregistreringContext} from '../../ducks/brukerregistrering';
+import {BrukerInfoContext} from '../../ducks/bruker-info';
+import {OppfolgingContext} from '../../ducks/oppfolging';
+import {klikkPaDineOpplysninger, loggAktivitet, seDineOpplysninger} from '../../metrics/metrics';
 import Opplysninger from '../innsyn/registreringsopplysninger';
 import './registrert.less';
-import { AmplitudeAktivitetsProps } from '../../metrics/amplitude-utils';
+import {AmplitudeAktivitetsProps} from '../../metrics/amplitude-utils';
+import {AutentiseringContext, InnloggingsNiva} from "../../ducks/autentisering";
 
 const Registrert = (props: AmplitudeAktivitetsProps) => {
     const brukerregistreringData = useContext(BrukerregistreringContext).data;
     const brukerinfoData = React.useContext(BrukerInfoContext).data;
     const oppfolgingData = React.useContext(OppfolgingContext).data;
+    const autentiseringData = React.useContext(AutentiseringContext).data;
     const [clickedInnsyn, setClickedInnsyn] = useState(false);
+
+    const kanViseKomponent = oppfolgingData.formidlingsgruppe === 'ARBS' && autentiseringData.securityLevel === InnloggingsNiva.LEVEL_4;
+    if (!kanViseKomponent) {
+        return null;
+    }
+
     const { amplitudeAktivitetsData } = props;
     if (!brukerregistreringData) {
         return (

--- a/src/mocks/auth-mock.ts
+++ b/src/mocks/auth-mock.ts
@@ -1,4 +1,4 @@
-import { InnloggingsNiva } from '../komponenter/hent-initial-data/autentiseringsInfoFetcher';
+import {InnloggingsNiva} from "../ducks/autentisering";
 
 export default {
     loggedIn: true,


### PR DESCRIPTION
I dag ligger regelene som bestemmer hvilke komponenter som skal vises ganske langt unna komponentene selv.
For eksempel har vi innhold-logikk-niva3/4 som har forskjellige regler for hvilke komponenter som skal vises og når.

Tanken med denne endringen er å la komponentene selv definere når de vises, sammen med hva de viser.

Neste steg blir å fjerne niva3/4-view-laget, og heller la komponentene selv si om de krever nivå 3 eller 4.