### PR TITLE
Opprydding i data-provider-imports

### DIFF
--- a/src/komponenter/hent-initial-data/autentiseringsInfoFetcher.tsx
+++ b/src/komponenter/hent-initial-data/autentiseringsInfoFetcher.tsx
@@ -7,24 +7,18 @@ import DataProvider from './data-provider';
 import InnholdLogikkNiva4 from '../../innhold/innhold-logikk-niva4';
 import InnholdLogikkNiva3 from '../../innhold/innhold-logikk-niva3';
 import OppfolgingBrukerregistreringProvider from './oppfolging-brukerregistrering-provider';
-
-import {
-    Data as AutentiseringData,
-    State as AutentiseringState,
-    initialState,
-    InnloggingsNiva,
-    AutentiseringContext,
-} from '../../ducks/autentisering';
+import * as Autentisering from '../../ducks/autentisering';
+import { InnloggingsNiva } from '../../ducks/autentisering';
 
 export const AUTH_API = '/api/auth';
 
 const AutentiseringsInfoFetcher = () => {
-    const [state, setState] = React.useState<AutentiseringState>(initialState);
+    const [state, setState] = React.useState<Autentisering.State>(Autentisering.initialState);
 
     const contextpath = erMikrofrontend() ? contextpathDittNav : '';
 
     React.useEffect(() => {
-        fetchData<AutentiseringState, AutentiseringData>(state, setState, `${contextpath}${AUTH_API}`);
+        fetchData<Autentisering.State, Autentisering.Data>(state, setState, `${contextpath}${AUTH_API}`);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -34,7 +28,7 @@ const AutentiseringsInfoFetcher = () => {
             storrelse="XXL"
             avhengigheter={[state]}
         >
-            <AutentiseringContext.Provider value={state}>
+            <Autentisering.AutentiseringContext.Provider value={state}>
                 {state.data.securityLevel === InnloggingsNiva.LEVEL_3 ? (
                     <InnholdLogikkNiva3 />
                 ) : (
@@ -44,7 +38,7 @@ const AutentiseringsInfoFetcher = () => {
                         </DataProvider>
                     </OppfolgingBrukerregistreringProvider>
                 )}
-            </AutentiseringContext.Provider>
+            </Autentisering.AutentiseringContext.Provider>
         </Innholdslaster>
     );
 };

--- a/src/komponenter/hent-initial-data/data-provider.tsx
+++ b/src/komponenter/hent-initial-data/data-provider.tsx
@@ -4,35 +4,16 @@ import { Dispatch } from '../../dispatch-type';
 import { AppState } from '../../reducer';
 import Innholdslaster from '../innholdslaster/innholdslaster';
 import Feilmelding from '../feilmeldinger/feilmelding';
-import {
-    State as BrukerInfoState,
-    Data as BrukerInfoData,
-    initialState as brukerInfoDataInitialstate,
-    BrukerInfoContext,
-} from '../../ducks/bruker-info';
+import * as BrukerInfo from '../../ducks/bruker-info';
+import * as Brukerregistrering from '../../ducks/brukerregistrering';
+import * as Motestotte from '../../ducks/motestotte';
+import * as Egenvurdering from '../../ducks/egenvurdering';
 import { hentUlesteDialoger, State as UlesteDialogerState } from '../../ducks/dialog';
-import {
-    BrukerregistreringContext,
-    ForeslattInnsatsgruppe,
-    selectForeslattInnsatsgruppe,
-} from '../../ducks/brukerregistrering';
 import { hentJobbsokerbesvarelse, State as JobbsokerbesvarelseState } from '../../ducks/jobbsokerbesvarelse';
-import {
-    Data as MotestotteData,
-    initialState as initialStateMotestotte,
-    State as MotestotteState,
-    MotestotteContext,
-} from '../../ducks/motestotte';
-import {
-    Data as EgenvurderingData,
-    initialState as initialStateEgenvurdering,
-    State as EgenvurderingState,
-    EgenvurderingContext,
-} from '../../ducks/egenvurdering';
-
 import { fetchData } from '../../ducks/api-utils';
 import { MOTESTOTTE_URL, BRUKERINFO_URL, EGENVURDERINGBESVARELSE_URL } from '../../ducks/api';
 import { AmplitudeProvider } from './amplitude-provider';
+import { ForeslattInnsatsgruppe, selectForeslattInnsatsgruppe } from '../../ducks/brukerregistrering';
 
 const skalSjekkeEgenvurderingBesvarelse = (
     foreslaattInnsatsgruppe: ForeslattInnsatsgruppe | undefined | null
@@ -66,25 +47,25 @@ const DataProvider = ({
     hentJobbsokerbesvarelse,
     hentUlesteDialoger,
 }: Props) => {
-    const [motestotteState, setMotestotteState] = React.useState<MotestotteState>(initialStateMotestotte);
-    const [brukerInfoState, setBrukerInfoState] = React.useState<BrukerInfoState>(brukerInfoDataInitialstate);
-    const [egenvurderingState, setEgenvurderingState] = React.useState<EgenvurderingState>(initialStateEgenvurdering);
+    const [motestotteState, setMotestotteState] = React.useState<Motestotte.State>(Motestotte.initialState);
+    const [brukerInfoState, setBrukerInfoState] = React.useState<BrukerInfo.State>(BrukerInfo.initialState);
+    const [egenvurderingState, setEgenvurderingState] = React.useState<Egenvurdering.State>(Egenvurdering.initialState);
 
-    const data = React.useContext(BrukerregistreringContext).data;
+    const data = React.useContext(Brukerregistrering.BrukerregistreringContext).data;
     const foreslaattInnsatsgruppe = selectForeslattInnsatsgruppe(data);
 
     React.useEffect(() => {
-        fetchData<BrukerInfoState, BrukerInfoData>(brukerInfoState, setBrukerInfoState, BRUKERINFO_URL);
+        fetchData<BrukerInfo.State, BrukerInfo.Data>(brukerInfoState, setBrukerInfoState, BRUKERINFO_URL);
         hentJobbsokerbesvarelse();
         hentUlesteDialoger();
         if (skalSjekkeEgenvurderingBesvarelse(foreslaattInnsatsgruppe)) {
-            fetchData<EgenvurderingState, EgenvurderingData>(
+            fetchData<Egenvurdering.State, Egenvurdering.Data>(
                 egenvurderingState,
                 setEgenvurderingState,
                 EGENVURDERINGBESVARELSE_URL
             );
         } else if (foreslaattInnsatsgruppe === ForeslattInnsatsgruppe.BEHOV_FOR_ARBEIDSEVNEVURDERING) {
-            fetchData<MotestotteState, MotestotteData>(motestotteState, setMotestotteState, MOTESTOTTE_URL);
+            fetchData<Motestotte.State, Motestotte.Data>(motestotteState, setMotestotteState, MOTESTOTTE_URL);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
@@ -105,13 +86,13 @@ const DataProvider = ({
             avhengigheter={avhengigheter}
             ventPa={ventPa}
         >
-            <BrukerInfoContext.Provider value={brukerInfoState}>
-                <MotestotteContext.Provider value={motestotteState}>
-                    <EgenvurderingContext.Provider value={egenvurderingState}>
+            <BrukerInfo.BrukerInfoContext.Provider value={brukerInfoState}>
+                <Motestotte.MotestotteContext.Provider value={motestotteState}>
+                    <Egenvurdering.EgenvurderingContext.Provider value={egenvurderingState}>
                         <AmplitudeProvider>{children}</AmplitudeProvider>
-                    </EgenvurderingContext.Provider>
-                </MotestotteContext.Provider>
-            </BrukerInfoContext.Provider>
+                    </Egenvurdering.EgenvurderingContext.Provider>
+                </Motestotte.MotestotteContext.Provider>
+            </BrukerInfo.BrukerInfoContext.Provider>
         </Innholdslaster>
     );
 };

--- a/src/komponenter/hent-initial-data/oppfolging-brukerregistrering-provider.tsx
+++ b/src/komponenter/hent-initial-data/oppfolging-brukerregistrering-provider.tsx
@@ -1,25 +1,9 @@
 import * as React from 'react';
 import Innholdslaster from '../innholdslaster/innholdslaster';
-import {
-    State as OppfolgingState,
-    Data as OppfolgingData,
-    initialState as oppfolgingInitialState,
-    OppfolgingContext,
-} from '../../ducks/oppfolging';
+import * as Oppfolging from '../../ducks/oppfolging';
 import Feilmelding from '../feilmeldinger/feilmelding';
-import {
-    State as BrukerregistreringState,
-    Data as BrukerregistreringData,
-    initialState as brukerregistreringInitialState,
-    BrukerregistreringContext,
-} from '../../ducks/brukerregistrering';
-import {
-    Data as FeatureTogglesData,
-    initialState as featureTogglesInitialState,
-    State as FeatureTogglesState,
-    FeaturetoggleContext,
-    alleFeatureToggles,
-} from '../../ducks/feature-toggles';
+import * as Brukerregistrering from '../../ducks/brukerregistrering';
+import * as FeatureToggle from '../../ducks/feature-toggles';
 import { fetchData } from '../../ducks/api-utils';
 import { BRUKERREGISTRERING_URL, VEILARBOPPFOLGING_URL, FEATURE_URL } from '../../ducks/api';
 import SjekkOppfolging from './sjekk-oppfolging';
@@ -31,22 +15,22 @@ interface OwnProps {
 type OppfolgingProviderProps = OwnProps;
 
 const OppfolgingBrukerregistreringProvider = ({ children }: OppfolgingProviderProps) => {
-    const [brukerregistreringState, setBrukerregistreringState] = React.useState<BrukerregistreringState>(
-        brukerregistreringInitialState
+    const [brukerregistreringState, setBrukerregistreringState] = React.useState<Brukerregistrering.State>(
+        Brukerregistrering.initialState
     );
-    const [oppfolgingState, setOppfolgingState] = React.useState<OppfolgingState>(oppfolgingInitialState);
-    const [featureToggleState, setFeatureToggleState] = React.useState<FeatureTogglesState>(featureTogglesInitialState);
-    const parameters = alleFeatureToggles.map((element) => 'feature=' + element).join('&');
+    const [oppfolgingState, setOppfolgingState] = React.useState<Oppfolging.State>(Oppfolging.initialState);
+    const [featureToggleState, setFeatureToggleState] = React.useState<FeatureToggle.State>(FeatureToggle.initialState);
+    const parameters = FeatureToggle.alleFeatureToggles.map((element) => 'feature=' + element).join('&');
     const featureTogglesUrl = `${FEATURE_URL}/?${parameters}`;
 
     React.useEffect(() => {
-        fetchData<OppfolgingState, OppfolgingData>(oppfolgingState, setOppfolgingState, VEILARBOPPFOLGING_URL);
-        fetchData<BrukerregistreringState, BrukerregistreringData>(
+        fetchData<Oppfolging.State, Oppfolging.Data>(oppfolgingState, setOppfolgingState, VEILARBOPPFOLGING_URL);
+        fetchData<Brukerregistrering.State, Brukerregistrering.Data>(
             brukerregistreringState,
             setBrukerregistreringState,
             BRUKERREGISTRERING_URL
         );
-        fetchData<FeatureTogglesState, FeatureTogglesData>(
+        fetchData<FeatureToggle.State, FeatureToggle.Data>(
             featureToggleState,
             setFeatureToggleState,
             featureTogglesUrl
@@ -60,15 +44,15 @@ const OppfolgingBrukerregistreringProvider = ({ children }: OppfolgingProviderPr
             storrelse="XXL"
             avhengigheter={[oppfolgingState, brukerregistreringState]}
         >
-            <OppfolgingContext.Provider value={oppfolgingState}>
+            <Oppfolging.OppfolgingContext.Provider value={oppfolgingState}>
                 <SjekkOppfolging underOppfolging={oppfolgingState.data.underOppfolging}>
-                    <BrukerregistreringContext.Provider value={brukerregistreringState}>
-                        <FeaturetoggleContext.Provider value={featureToggleState}>
+                    <Brukerregistrering.BrukerregistreringContext.Provider value={brukerregistreringState}>
+                        <FeatureToggle.FeaturetoggleContext.Provider value={featureToggleState}>
                             {children}
-                        </FeaturetoggleContext.Provider>
-                    </BrukerregistreringContext.Provider>
+                        </FeatureToggle.FeaturetoggleContext.Provider>
+                    </Brukerregistrering.BrukerregistreringContext.Provider>
                 </SjekkOppfolging>
-            </OppfolgingContext.Provider>
+            </Oppfolging.OppfolgingContext.Provider>
         </Innholdslaster>
     );
 };


### PR DESCRIPTION
Gjør tilsvarende som i `test-context-provider` for å skape et mer håndterbart mønster.