### PR TITLE
Setter default for uker registrert til INGEN_DATO

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,9 @@
             "integrity": "sha512-VbQuJymJ20WEw0HtI2np7EdC3NJGUWi8+Xdbc7uk8WfMIF308T0howpzkQ3JFMN7ejnrcSM/OyNGveeE3TP3TA=="
         },
         "@amplitude/utils": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@amplitude/utils/-/utils-1.5.0.tgz",
-            "integrity": "sha512-1DrDJkb4dVX+FiBXhGpO2Dn2cRKdP+gtrVR8vZcE8wz/V2XxUI3DDx7uQbIS6WbQf6swv6Uo2eMHYtrwebostw==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@amplitude/utils/-/utils-1.5.1.tgz",
+            "integrity": "sha512-B7xBC6/arymfmwM7sEnvT0jbYg/7+CnSA8s98adV6mNNYT2kOIJN7AVUghoA9oD2wJE1s2GavJeyFZlgQj6uiQ==",
             "requires": {
                 "@amplitude/types": "^1.5.0",
                 "tslib": "^1.9.3"
@@ -38,9 +38,9 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.13.8",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
-            "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==",
+            "version": "7.13.11",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.11.tgz",
+            "integrity": "sha512-BwKEkO+2a67DcFeS3RLl0Z3Gs2OvdXewuWjc1Hfokhb5eQWP9YRYH1/+VrVZvql2CfjOiNGqSAFOYt4lsqTHzg==",
             "dev": true
         },
         "@babel/core": {
@@ -134,9 +134,9 @@
             }
         },
         "@babel/helper-create-class-features-plugin": {
-            "version": "7.13.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.10.tgz",
-            "integrity": "sha512-YV7r2YxdTUaw84EwNkyrRke/TJHR/UXGiyvACRqvdVJ2/syV2rQuJNnaRLSuYiop8cMRXOgseTGoJCWX0q2fFg==",
+            "version": "7.13.11",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.11.tgz",
+            "integrity": "sha512-ays0I7XYq9xbjCSvT+EvysLgfc3tOkwCULHjrnscGT3A9qD4sk3wXnJ3of0MAWsWGjdinFvajHU2smYuqXKMrw==",
             "dev": true,
             "requires": {
                 "@babel/helper-function-name": "^7.12.13",
@@ -379,9 +379,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.13.10",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.10.tgz",
-            "integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==",
+            "version": "7.13.11",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.11.tgz",
+            "integrity": "sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q==",
             "dev": true
         },
         "@babel/plugin-proposal-async-generator-functions": {
@@ -2723,9 +2723,9 @@
             "dev": true
         },
         "@types/babel__core": {
-            "version": "7.1.12",
-            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
-            "integrity": "sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==",
+            "version": "7.1.13",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.13.tgz",
+            "integrity": "sha512-CC6amBNND16pTk4K3ZqKIaba6VGKAQs3gMjEY17FVd56oI/ZWt9OhS6riYiWv9s8ENbYUi7p8lgqb0QHQvUKQQ==",
             "dev": true,
             "requires": {
                 "@babel/parser": "^7.1.0",
@@ -2755,9 +2755,9 @@
             }
         },
         "@types/babel__traverse": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.11.0.tgz",
-            "integrity": "sha512-kSjgDMZONiIfSH1Nxcr5JIRMwUetDki63FSQfpTCz8ogF3Ulqm8+mr5f78dUYs6vMiB6gBusQqfQmBvHZj/lwg==",
+            "version": "7.11.1",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.11.1.tgz",
+            "integrity": "sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.3.0"
@@ -5020,9 +5020,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001199",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001199.tgz",
-            "integrity": "sha512-ifbK2eChUCFUwGhlEzIoVwzFt1+iriSjyKKFYNfv6hN34483wyWpLLavYQXhnR036LhkdUYaSDpHg1El++VgHQ==",
+            "version": "1.0.30001202",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001202.tgz",
+            "integrity": "sha512-ZcijQNqrcF8JNLjzvEiXqX4JUYxoZa7Pvcsd9UD8Kz4TvhTonOSNRsK+qtvpVL4l6+T1Rh4LFtLfnNWg6BGWCQ==",
             "dev": true
         },
         "capture-exit": {
@@ -6565,9 +6565,9 @@
             "dev": true
         },
         "detect-node": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
-            "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.5.tgz",
+            "integrity": "sha512-qi86tE6hRcFHy8jI1m2VG+LaPUR1LhqDa5G8tVjuUXmOrpuAgqsA1pN0+ldgr3aKUH+QLI9hCY/OcRYisERejw==",
             "dev": true
         },
         "detect-port-alt": {
@@ -6935,9 +6935,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.687",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
-            "integrity": "sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ==",
+            "version": "1.3.690",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.690.tgz",
+            "integrity": "sha512-zPbaSv1c8LUKqQ+scNxJKv01RYFkVVF1xli+b+3Ty8ONujHjAMg+t/COmdZqrtnS1gT+g4hbSodHillymt1Lww==",
             "dev": true
         },
         "elfy": {
@@ -9462,9 +9462,9 @@
             "dev": true
         },
         "headers-utils": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/headers-utils/-/headers-utils-1.2.4.tgz",
-            "integrity": "sha512-z1l0UdLhNZVs33v7NtzenJ7M4w0DCk484UaDmepOi4ooNp4353erwn8yzut0MP3TFB3wJFP992Cm4pSbmSui5A==",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/headers-utils/-/headers-utils-1.2.5.tgz",
+            "integrity": "sha512-DAzV5P/pk3wTU/8TLZN+zFTDv4Xa1QDTU8pRvovPetcOMbmqq8CwsAvZBLPZHH6usxyy31zMp7I4aCYb6XIf6w==",
             "dev": true
         },
         "hex-color-regex": {
@@ -23525,9 +23525,9 @@
             "dev": true
         },
         "yaml": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-            "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "dev": true
         },
         "yargs": {

--- a/src/ducks/amplitude-context.ts
+++ b/src/ducks/amplitude-context.ts
@@ -8,7 +8,7 @@ export const initialState: AmplitudeData = {
     isKSSX: 'nei',
     isKSSK: 'nei',
     erSamarbeidskontor: 'nei',
-    ukerRegistrert: 0,
+    ukerRegistrert: 'INGE_DATO',
     nivaa: InnloggingsNiva.LEVEL_3,
     kanReaktiveres: 'nei',
     formidlingsgruppe: 'INGEN_VERDI',

--- a/src/ducks/amplitude-context.ts
+++ b/src/ducks/amplitude-context.ts
@@ -8,7 +8,7 @@ export const initialState: AmplitudeData = {
     isKSSX: 'nei',
     isKSSK: 'nei',
     erSamarbeidskontor: 'nei',
-    ukerRegistrert: 'INGE_DATO',
+    ukerRegistrert: 'INGEN_DATO',
     nivaa: InnloggingsNiva.LEVEL_3,
     kanReaktiveres: 'nei',
     formidlingsgruppe: 'INGEN_VERDI',

--- a/src/komponenter/hent-initial-data/amplitude-provider.tsx
+++ b/src/komponenter/hent-initial-data/amplitude-provider.tsx
@@ -68,7 +68,7 @@ export const AmplitudeProvider = (props: { children: React.ReactNode }) => {
         ? new Date(opprettetRegistreringDatoString)
         : null;
     const geografiskTilknytningOrIngenVerdi = geografiskTilknytning || 'INGEN_VERDI';
-    const ukerRegistrert = opprettetRegistreringDato ? ukerFraDato(opprettetRegistreringDato) : ukerFraDato(new Date());
+    const ukerRegistrert = opprettetRegistreringDato ? ukerFraDato(opprettetRegistreringDato) : 'INGEN_DATO';
     const servicegruppeOrIVURD = servicegruppe || 'IVURD';
     const foreslattInnsatsgruppeOrIngenVerdi =
         brukerregistreringData?.registrering?.profilering?.innsatsgruppe || 'INGEN_VERDI';

--- a/src/metrics/amplitude-utils.ts
+++ b/src/metrics/amplitude-utils.ts
@@ -28,7 +28,7 @@ export type AmplitudeData = {
     isKSSX: string;
     isKSSK: string;
     erSamarbeidskontor: string;
-    ukerRegistrert: number;
+    ukerRegistrert: number | 'INGEN_DATO';
     nivaa: InnloggingsNiva;
     kanReaktiveres: string;
     formidlingsgruppe: string;


### PR DESCRIPTION
Frem til nå har vi satt dagens dato som utregningstidspunkt for ukerRegistrert dersom dato mangler.
Dette har ført til at uke 0 kan bety både nyregistrert og registrert på andre måter slik at dato mangler.

Denne PR setter default verdi til `INGEN_DATO` slik at vi fremover enkelt kan skille mellom ekte nyregistrerte og de som fremstår slik.