### PR TITLE
InViewport komponent

### DIFF
--- a/src/innhold/innhold-metrics.tsx
+++ b/src/innhold/innhold-metrics.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import handleViewport from 'react-in-viewport';
 import { AmplitudeContext } from '../ducks/amplitude-context';
 import {
     BrukerregistreringContext,
@@ -16,14 +15,7 @@ import { hotjarTrigger } from '../hotjar';
 import { AutentiseringContext, InnloggingsNiva } from '../ducks/autentisering';
 import { UnderOppfolgingContext } from '../ducks/under-oppfolging';
 
-interface ViewportProps {
-    inViewport: boolean;
-    forwardedRef: React.ForwardedRef<any>;
-}
-
 type Props = {};
-
-const WrappedMetrics: React.ComponentType<Props> = handleViewport(Metrics);
 
 export default function InnholdMetrics() {
     const { securityLevel } = React.useContext(AutentiseringContext).data;
@@ -31,11 +23,10 @@ export default function InnholdMetrics() {
 
     if (!underOppfolging || securityLevel === InnloggingsNiva.LEVEL_3) return null;
 
-    return <WrappedMetrics />;
+    return <Metrics />;
 }
 
-function Metrics(props: Props & ViewportProps) {
-    const [harVistTilBruker, setHarVistTilBruker] = React.useState<boolean>(false);
+function Metrics(props: Props) {
     const { formidlingsgruppe, servicegruppe } = React.useContext(OppfolgingContext).data;
     const amplitudeData = React.useContext(AmplitudeContext);
     const { antallDagerEtterFastsattMeldingsdag } = amplitudeData;
@@ -69,21 +60,11 @@ function Metrics(props: Props & ViewportProps) {
         return parseInt(antallDagerEtterFastsattMeldingsdag, 10) >= 1;
     };
 
-    if (props.inViewport && !harVistTilBruker) {
-        setHarVistTilBruker(true);
-    }
-
     React.useEffect(() => {
         hotjarTrigger(erMikrofrontend(), POAGruppe, hotjarEksperiment());
         loggVisning({ viser: 'Viser veien til arbeid', ...amplitudeData });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    React.useEffect(() => {
-        if (harVistTilBruker) {
-            loggVisning({ viser: 'Veien til arbeid i viewport', ...amplitudeData });
-        }
-    }, [amplitudeData, harVistTilBruker]);
-
-    return <span ref={props.forwardedRef}></span>;
+    return null;
 }

--- a/src/innhold/innhold-view.tsx
+++ b/src/innhold/innhold-view.tsx
@@ -13,11 +13,13 @@ import Registrert from '../komponenter/registrert/registrert';
 import AktivitetDialogMeldekort from './aktivitet-dialog-meldekort';
 import InnholdMetrics from './innhold-metrics';
 import GenerelleFliser from '../komponenter/dittnav/generelle-fliser';
+import InViewport from '../komponenter/in-viewport/in-viewport';
 
 const InnholdView = () => {
     return (
         <>
             <InnholdMetrics />
+            <InViewport loggTekst="Veien til arbeid i viewport" />
             <Banner />
             <Rad>
                 <ReaktiveringKort />

--- a/src/komponenter/in-viewport/in-viewport.tsx
+++ b/src/komponenter/in-viewport/in-viewport.tsx
@@ -6,10 +6,11 @@ import { loggVisning } from '../../metrics/metrics';
 interface ViewportProps {
     inViewport: boolean;
     forwardedRef: React.ForwardedRef<any>;
-    loggTekst: string;
 }
 
-type Props = {};
+type Props = {
+    loggTekst: string;
+};
 
 const WrappedViewport: React.ComponentType<Props> = handleViewport(InViewport);
 
@@ -26,6 +27,8 @@ function InViewport(props: Props & ViewportProps) {
             loggVisning({ viser: props.loggTekst, ...amplitudeData });
         }
     }, [amplitudeData, harVistTilBruker]);
+
+    return <span ref={props.forwardedRef}></span>;
 }
 
 export default WrappedViewport;

--- a/src/komponenter/in-viewport/in-viewport.tsx
+++ b/src/komponenter/in-viewport/in-viewport.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import handleViewport from 'react-in-viewport';
+import { AmplitudeContext } from '../../ducks/amplitude-context';
+import { loggVisning } from '../../metrics/metrics';
+
+interface ViewportProps {
+    inViewport: boolean;
+    forwardedRef: React.ForwardedRef<any>;
+    loggTekst: string;
+}
+
+type Props = {};
+
+const WrappedViewport: React.ComponentType<Props> = handleViewport(InViewport);
+
+function InViewport(props: Props & ViewportProps) {
+    const [harVistTilBruker, setHarVistTilBruker] = React.useState<boolean>(false);
+    const amplitudeData = React.useContext(AmplitudeContext);
+
+    if (props.inViewport && !harVistTilBruker) {
+        setHarVistTilBruker(true);
+    }
+
+    React.useEffect(() => {
+        if (harVistTilBruker) {
+            loggVisning({ viser: props.loggTekst, ...amplitudeData });
+        }
+    }, [amplitudeData, harVistTilBruker]);
+}
+
+export default WrappedViewport;


### PR DESCRIPTION
- Lager egen komponent for InViewport som kan inkluderes hvor som helst i løsningen man vil logge inViewport aktivitet til Amplitude
- Fjerner inviewport-logikken fra innhold-metrics
- Legger til InViewport komponenten på toppen av innhold-view