### PR TITLE
Registrert som permittert

### DIFF
--- a/src/demo/demo-dashboard.tsx
+++ b/src/demo/demo-dashboard.tsx
@@ -39,12 +39,14 @@ import {
 } from './demo-state';
 
 import './demo-dashboard.less';
-import { ForeslattInnsatsgruppe, FremtidigSituasjonSvar } from '../ducks/brukerregistrering';
+import { DinSituasjonSvar, ForeslattInnsatsgruppe, FremtidigSituasjonSvar } from '../ducks/brukerregistrering';
 import {
     hentForeslattInnsatsgruppe,
+    hentDinSituasjon,
     hentFremtidigSituasjon,
     hentOpprettetDato,
     settForeslattInnsatsgruppe,
+    settDinSituasjon,
     settFremtidigSituasjon,
     settOpprettetDato,
 } from './demo-state-brukerregistrering';
@@ -108,6 +110,11 @@ class DemoDashboard extends React.Component<{}> {
 
         const handleChangeBrukerregistrering = (e: React.ChangeEvent<HTMLSelectElement>) => {
             settFremtidigSituasjon(e.target.value as FremtidigSituasjonSvar);
+            window.location.reload();
+        };
+
+        const handleChangeDinSituasjon = (e: React.ChangeEvent<HTMLSelectElement>) => {
+            settDinSituasjon(e.target.value as DinSituasjonSvar);
             window.location.reload();
         };
 
@@ -195,6 +202,21 @@ class DemoDashboard extends React.Component<{}> {
             NY_ARBEIDSGIVER: 'Ny arbeidsgiver',
             USIKKER: 'Usikker',
             INGEN_PASSER: 'Ingen passer',
+        };
+
+        const dineSituasjoner = {
+            MISTET_JOBBEN: 'MISTET_JOBBEN',
+            ALDRI_HATT_JOBB: 'ALDRI_HATT_JOBB',
+            HAR_SAGT_OPP: 'HAR_SAGT_OPP',
+            VIL_BYTTE_JOBB: 'VIL_BYTTE_JOBB',
+            ER_PERMITTERT: 'ER_PERMITTERT',
+            USIKKER_JOBBSITUASJON: 'USIKKER_JOBBSITUASJON',
+            JOBB_OVER_2_AAR: 'JOBB_OVER_2_AAR',
+            VIL_FORTSETTE_I_JOBB: 'VIL_FORTSETTE_I_JOBB',
+            AKKURAT_FULLFORT_UTDANNING: 'AKKURAT_FULLFORT_UTDANNING',
+            DELTIDSJOBB_VIL_MER: 'DELTIDSJOBB_VIL_MER',
+            INGEN_SVAR: 'INGEN_SVAR',
+            INGEN_VERDI: 'INGEN_VERDI',
         };
 
         const foreslattInnsatsgrupper = {
@@ -306,6 +328,18 @@ class DemoDashboard extends React.Component<{}> {
                         {Object.keys(FremtidigSituasjonSvar).map((svar: string) => (
                             <option key={svar} value={svar}>
                                 {fremtidigeSituasjoner[svar]}
+                            </option>
+                        ))}
+                    </SelectKomponent>
+                    <SelectKomponent
+                        label="Velg dinSituasjon"
+                        onChange={handleChangeDinSituasjon}
+                        id="velg-din-situasjon"
+                        defaultValue={hentDinSituasjon()}
+                    >
+                        {Object.keys(DinSituasjonSvar).map((svar: string) => (
+                            <option key={svar} value={svar}>
+                                {dineSituasjoner[svar]}
                             </option>
                         ))}
                     </SelectKomponent>

--- a/src/demo/demo-state-brukerregistrering.ts
+++ b/src/demo/demo-state-brukerregistrering.ts
@@ -50,6 +50,7 @@ export const hentBrukerRegistrering = () => ({
         opprettetDato: hentOpprettetDato(),
         besvarelse: {
             ...defaultBesvarelse,
+            dinSituasjon: hentDinSituasjon(),
             fremtidigSituasjon: hentFremtidigSituasjon(),
         },
         profilering: {

--- a/src/demo/demo-state-brukerregistrering.ts
+++ b/src/demo/demo-state-brukerregistrering.ts
@@ -3,6 +3,7 @@ import { DemoData, hentDemoState, settDemoState } from './demo-state';
 import { opprettetRegistreringDato } from './demo-dashboard';
 
 const defaultFremtidigSituasjon = FremtidigSituasjonSvar.NY_ARBEIDSGIVER;
+const defaultDinSituasjon = DinSituasjonSvar.MISTET_JOBBEN;
 const defaultBesvarelse = {
     utdanning: 'INGEN_UTDANNING',
     utdanningBestatt: 'INGEN_SVAR',
@@ -10,7 +11,7 @@ const defaultBesvarelse = {
     helseHinder: 'NEI',
     andreForhold: 'NEI',
     sisteStilling: 'Barne- og ungdomsarbeider i skolefritidsordning',
-    dinSituasjon: DinSituasjonSvar.MISTET_JOBBEN,
+    dinSituasjon: defaultDinSituasjon,
     fremtidigSituasjon: defaultFremtidigSituasjon,
     tilbakeIArbeid: 'USIKKER',
 };

--- a/src/demo/demo-state-brukerregistrering.ts
+++ b/src/demo/demo-state-brukerregistrering.ts
@@ -64,6 +64,9 @@ export const hentFremtidigSituasjon = () => hentDemoState(DemoData.FREMTIDIG_SIT
 export const settFremtidigSituasjon = (fremtidigSituasjon: FremtidigSituasjonSvar) =>
     settDemoState(DemoData.FREMTIDIG_SITUASJON, fremtidigSituasjon);
 
+export const hentDinSituasjon = () => hentDemoState(DemoData.DIN_SITUASJON) || defaultDinSituasjon;
+export const settDinSituasjon = (dinSituasjon: DinSituasjonSvar) => settDemoState(DemoData.DIN_SITUASJON, dinSituasjon);
+
 export const hentForeslattInnsatsgruppe = () =>
     hentDemoState(DemoData.FORESLATT_INNSATSGRUPPE) || defaultForeslattInnsatsgruppe;
 export const settForeslattInnsatsgruppe = (innsatsgruppe: ForeslattInnsatsgruppe) =>

--- a/src/demo/demo-state.ts
+++ b/src/demo/demo-state.ts
@@ -28,6 +28,7 @@ export enum DemoData {
     UNDER_OPPFOLGING = 'underOppfolging',
     KAN_REAKTIVERES = 'kanReaktiveres',
     FREMTIDIG_SITUASJON = 'fremtidigSituasjon',
+    DIN_SITUASJON = 'dinSituasjon',
     FORESLATT_INNSATSGRUPPE = 'foreslattInnsatsgruppe',
     REGISTRERING_OPPRETTET = 'registreringOpprettet',
     SKJUL_DEMO = 'skjulDemo',

--- a/src/ducks/feature-toggles.ts
+++ b/src/ducks/feature-toggles.ts
@@ -4,6 +4,7 @@ import { DataElement, STATUS } from './api';
 export enum FeatureToggles {
     INTRO_FEEDBACK = 'veientilarbeid.feedback',
     INTRO_14A = 'veientilarbeid.14a-intro',
+    REGISTRERT_PERMITTERT = 'veientilarbeid.registrert-permittert',
 }
 
 export function prettyPrintFeatureToggle(toggle: FeatureToggles) {
@@ -12,12 +13,15 @@ export function prettyPrintFeatureToggle(toggle: FeatureToggles) {
             return '14a-intro';
         case FeatureToggles.INTRO_FEEDBACK:
             return 'Intro feedback';
+        case FeatureToggles.REGISTRERT_PERMITTERT:
+            return 'Registrert som permittert';
     }
 }
 
 export interface Data {
     'veientilarbeid.feedback': boolean;
     'veientilarbeid.14a-intro': boolean;
+    'veientilarbeid.registrert-permittert': boolean;
 }
 
 export interface State extends DataElement {
@@ -28,6 +32,7 @@ export const initialState: State = {
     data: {
         'veientilarbeid.feedback': false,
         'veientilarbeid.14a-intro': false,
+        'veientilarbeid.registrert-permittert': false,
     },
     status: STATUS.NOT_STARTED,
 };

--- a/src/komponenter/registrert/permittert.tsx
+++ b/src/komponenter/registrert/permittert.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Normaltekst } from 'nav-frontend-typografi';
 import Lenke from 'nav-frontend-lenker';
+import { AmplitudeContext } from '../../ducks/amplitude-context';
+import { amplitudeLogger } from '../../metrics/amplitude-utils';
 import './registrert.less';
 
 interface Props {
@@ -8,7 +10,23 @@ interface Props {
 }
 
 function Permittert(props: Props) {
+    const amplitudeData = React.useContext(AmplitudeContext);
     const { visRegistrertSomPermittert } = props;
+
+    const handleLesEndretSituasjon = () => {
+        amplitudeLogger('veientilarbeid.aktivitet', {
+            handling: 'Går til les om endret situasjon fra registrert som permittert',
+            ...amplitudeData,
+        });
+    };
+
+    const handleLesDagpenger = () => {
+        amplitudeLogger('veientilarbeid.aktivitet', {
+            handling: 'Går til les om dagpenger og permittering fra registrert som permittert',
+            ...amplitudeData,
+        });
+    };
+
     if (!visRegistrertSomPermittert) return null;
     return (
         <div className="permittert-blokk">
@@ -17,14 +35,17 @@ function Permittert(props: Props) {
             </Normaltekst>
             <Normaltekst>
                 Når du har begynt i jobben din igjen, eller mister jobben, så{' '}
-                <Lenke href="https://www.nav.no/arbeid/no/dagpenger#gi-beskjed-hvis-situasjonen-din-endrer-seg">
+                <Lenke
+                    onClick={handleLesEndretSituasjon}
+                    href="https://www.nav.no/arbeid/no/dagpenger#gi-beskjed-hvis-situasjonen-din-endrer-seg"
+                >
                     gir du beskjed til NAV slik
                 </Lenke>
                 .
             </Normaltekst>
             <Normaltekst>
                 Du finner{' '}
-                <Lenke href="https://www.nav.no/arbeid/no/permittert">
+                <Lenke onClick={handleLesDagpenger} href="https://www.nav.no/arbeid/no/permittert">
                     informasjon om dagpenger og permittering her
                 </Lenke>
                 .

--- a/src/komponenter/registrert/permittert.tsx
+++ b/src/komponenter/registrert/permittert.tsx
@@ -3,6 +3,7 @@ import { Normaltekst } from 'nav-frontend-typografi';
 import Lenke from 'nav-frontend-lenker';
 import { AmplitudeContext } from '../../ducks/amplitude-context';
 import { amplitudeLogger } from '../../metrics/amplitude-utils';
+import ErRendret from '../er-rendret/er-rendret';
 import './registrert.less';
 
 interface Props {
@@ -50,6 +51,7 @@ function Permittert(props: Props) {
                 </Lenke>
                 .
             </Normaltekst>
+            <ErRendret loggTekst="Rendrer registrert som permittert boks" />
         </div>
     );
 }

--- a/src/komponenter/registrert/permittert.tsx
+++ b/src/komponenter/registrert/permittert.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Normaltekst } from 'nav-frontend-typografi';
+import Lenke from 'nav-frontend-lenker';
 import './registrert.less';
 
 interface Props {
@@ -15,9 +16,19 @@ function Permittert(props: Props) {
                 Ha tett kontakt med arbeidsgiveren din om situasjonen fremover, nå når du er permittert.
             </Normaltekst>
             <Normaltekst>
-                Når du har begynt i jobben din igjen, eller mister jobben, så gir du beskjed til NAV slik.
+                Når du har begynt i jobben din igjen, eller mister jobben, så{' '}
+                <Lenke href="https://www.nav.no/arbeid/no/dagpenger#gi-beskjed-hvis-situasjonen-din-endrer-seg">
+                    gir du beskjed til NAV slik
+                </Lenke>
+                .
             </Normaltekst>
-            <Normaltekst>Du finner informasjon om dagpenger og permittering her.</Normaltekst>
+            <Normaltekst>
+                Du finner{' '}
+                <Lenke href="https://www.nav.no/arbeid/no/permittert">
+                    informasjon om dagpenger og permittering her
+                </Lenke>
+                .
+            </Normaltekst>
         </div>
     );
 }

--- a/src/komponenter/registrert/permittert.tsx
+++ b/src/komponenter/registrert/permittert.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Normaltekst } from 'nav-frontend-typografi';
+import './registrert.less';
+
+interface Props {
+    visRegistrertSomPermittert: boolean;
+}
+
+function Permittert(props: Props) {
+    const { visRegistrertSomPermittert } = props;
+    if (!visRegistrertSomPermittert) return null;
+    return (
+        <div className="permittert-blokk">
+            <Normaltekst>
+                Ha tett kontakt med arbeidsgiveren din om situasjonen fremover, nå når du er permittert.
+            </Normaltekst>
+            <Normaltekst>
+                Når du har begynt i jobben din igjen, eller mister jobben, så gir du beskjed til NAV slik.
+            </Normaltekst>
+            <Normaltekst>Du finner informasjon om dagpenger og permittering her.</Normaltekst>
+        </div>
+    );
+}
+
+export default Permittert;

--- a/src/komponenter/registrert/registrert.less
+++ b/src/komponenter/registrert/registrert.less
@@ -33,6 +33,10 @@ registrering-info:hover {
     border-top: 1px solid @navGra20;
 }
 
+.permittert-blokk {
+    padding: 1rem;
+    line-height: 1.375rem;
+}
 @media (min-width: @screen-md-min) {
     .intro-wrapper {
        flex-direction: row;

--- a/src/komponenter/registrert/registrert.tsx
+++ b/src/komponenter/registrert/registrert.tsx
@@ -14,6 +14,7 @@ import { UnderOppfolgingContext } from '../../ducks/under-oppfolging';
 import { FeaturetoggleContext } from '../../ducks/feature-toggles';
 import Intro14AWrapper from '../14a-intro/14a';
 import InViewport from '../in-viewport/in-viewport';
+import Permittert from './permittert';
 
 const Registrert = () => {
     const brukerregistreringData = useContext(BrukerregistreringContext).data;
@@ -67,6 +68,7 @@ const Registrert = () => {
             <AlertStripeInfo className={showOpplysninger ? 'registrering-info' : ''}>
                 <Element>{tittel}</Element>
             </AlertStripeInfo>
+            <Permittert visRegistrertSomPermittert={visRegistrertSomPermittert} />
             {showOpplysninger ? (
                 <Ekspanderbartpanel
                     tittel="Se svarene dine fra registreringen"

--- a/src/komponenter/registrert/registrert.tsx
+++ b/src/komponenter/registrert/registrert.tsx
@@ -11,6 +11,7 @@ import { OppfolgingContext } from '../../ducks/oppfolging';
 import { AutentiseringContext, InnloggingsNiva } from '../../ducks/autentisering';
 import { AmplitudeContext } from '../../ducks/amplitude-context';
 import { UnderOppfolgingContext } from '../../ducks/under-oppfolging';
+import { FeaturetoggleContext } from '../../ducks/feature-toggles';
 import Intro14AWrapper from '../14a-intro/14a';
 import InViewport from '../in-viewport/in-viewport';
 
@@ -19,8 +20,11 @@ const Registrert = () => {
     const oppfolgingData = React.useContext(OppfolgingContext).data;
     const autentiseringData = React.useContext(AutentiseringContext).data;
     const amplitudeData = React.useContext(AmplitudeContext);
+    const featuretoggleData = React.useContext(FeaturetoggleContext).data;
     const [clickedInnsyn, setClickedInnsyn] = useState(false);
     const { underOppfolging } = React.useContext(UnderOppfolgingContext).data;
+
+    const featureToggleErAktivert = featuretoggleData['veientilarbeid.registrert-permittert'];
 
     const kanViseKomponent =
         oppfolgingData.formidlingsgruppe === 'ARBS' &&
@@ -30,6 +34,7 @@ const Registrert = () => {
     if (!kanViseKomponent) {
         return null;
     }
+
     if (!brukerregistreringData || !brukerregistreringData.registrering) {
         return (
             <div className="blokk-s">
@@ -44,6 +49,12 @@ const Registrert = () => {
     const { opprettetDato, manueltRegistrertAv, besvarelse, teksterForBesvarelse } = registrering;
     const showOpplysninger = opprettetDato && besvarelse && teksterForBesvarelse;
 
+    const visRegistrertSomPermittert = featureToggleErAktivert && besvarelse.dinSituasjon === 'ER_PERMITTERT';
+
+    const tittel = visRegistrertSomPermittert
+        ? 'Du er registrert som permittert (arbeidssøker)'
+        : 'Du er registrert som arbeidssøker';
+
     const handleClickOpen = () => {
         if (!clickedInnsyn) {
             loggAktivitet({ aktivitet: 'Ser opplysninger fra registreringen', ...amplitudeData });
@@ -54,7 +65,7 @@ const Registrert = () => {
     return (
         <div className="blokk-s registrerings-container">
             <AlertStripeInfo className={showOpplysninger ? 'registrering-info' : ''}>
-                <Element>Du er registrert som arbeidssøker</Element>
+                <Element>{tittel}</Element>
             </AlertStripeInfo>
             {showOpplysninger ? (
                 <Ekspanderbartpanel


### PR DESCRIPTION
Første iterasjon av registrert som permittert.

Dette er en egen variant av registrert boksen som skal vises for de som har valgt "ER_PERMITTERT" som situasjon.

Det er en annen tittel: "Du er registrert som permittert (arbeidssøker)" og ellers informasjon som er hentet fra dagens automatiske dialog. Målet er å kunne skru av dialogen og heller ha kommunikasjonen fra VTA.

Denne første PR innfører dinSituasjon i Demo og legger til versjon en av komponenten bak en featuretoggle