### PR TITLE
Scrollto registrering

### DIFF
--- a/src/komponenter/registrert/registrert.tsx
+++ b/src/komponenter/registrert/registrert.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Element } from 'nav-frontend-typografi';
 import { AlertStripeInfo } from 'nav-frontend-alertstriper';
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
@@ -31,6 +31,18 @@ const Registrert = () => {
         oppfolgingData.formidlingsgruppe === 'ARBS' &&
         autentiseringData.securityLevel === InnloggingsNiva.LEVEL_4 &&
         underOppfolging;
+
+    const scrollToRegistrering = () => {
+        const goto = new URLSearchParams(window.location.search).get('goTo');
+        const registreringsboks = document.getElementById('registrering-status-container');
+        if (goto === 'registrering' && registreringsboks) {
+            registreringsboks.scrollIntoView({ block: 'end', inline: 'nearest' });
+        }
+    };
+
+    useEffect(() => {
+        scrollToRegistrering();
+    }, []);
 
     if (!kanViseKomponent) {
         return null;

--- a/src/komponenter/registrert/registrert.tsx
+++ b/src/komponenter/registrert/registrert.tsx
@@ -64,7 +64,7 @@ const Registrert = () => {
     };
 
     return (
-        <div className="blokk-s registrerings-container">
+        <div id="registrering-status-container" className="blokk-s registrerings-container">
             <AlertStripeInfo className={showOpplysninger ? 'registrering-info' : ''}>
                 <Element>{tittel}</Element>
             </AlertStripeInfo>


### PR DESCRIPTION
Brukere som allerede er registrert og forsøker å registrere seg påny sendes direkte videre til dittNAV dersom de er ARBS.
Utfordringen er at de da havner på toppen av siden og med mindre de scroller seg et stykke ned ser de ikke informasjonen som sier de er registrert.

Denne PR åpner for at dersom man sender med `goTo=registrering` så scroller nettleseren registreringsboksen inn i viewPort.