### PR TITLE
Onboarding14a etter 12 uker

### DIFF
--- a/src/komponenter/14a-intro/14a-intro.test.tsx
+++ b/src/komponenter/14a-intro/14a-intro.test.tsx
@@ -59,7 +59,6 @@ describe('tester onboarding komponenten for 14a-intro', () => {
                 amplitude: { ukerRegistrert: 13 },
             }),
         });
-        screen.debug();
         expect(container).toBeEmptyDOMElement();
     });
 

--- a/src/komponenter/14a-intro/14a-intro.test.tsx
+++ b/src/komponenter/14a-intro/14a-intro.test.tsx
@@ -23,6 +23,11 @@ const providerProps: ProviderProps = {
         formidlingsgruppe: Formidlingsgruppe.ARBS,
         servicegruppe: Servicegruppe.IKVAL,
     },
+    brukerregistrering: {
+        registrering: {
+            opprettetDato: '2020-06-01',
+        },
+    },
 };
 
 describe('tester onboarding komponenten for 14a-intro', () => {
@@ -54,6 +59,7 @@ describe('tester onboarding komponenten for 14a-intro', () => {
                 amplitude: { ukerRegistrert: 13 },
             }),
         });
+        screen.debug();
         expect(container).toBeEmptyDOMElement();
     });
 

--- a/src/komponenter/14a-intro/14a-intro.test.tsx
+++ b/src/komponenter/14a-intro/14a-intro.test.tsx
@@ -51,15 +51,15 @@ describe('tester onboarding komponenten for 14a-intro', () => {
         expect(container).toBeEmptyDOMElement();
     });
 
-    test('komponenten vises IKKE når bruker har vært registrert i 13 uker', () => {
+    test('komponenten VISES også når bruker har vært registrert i 13 uker', () => {
         const { container } = render(<Intro14AWrapper />, {
             wrapper: contextProviders({
                 ...providerProps,
                 featureToggle: { 'veientilarbeid.14a-intro': true },
-                amplitude: { ukerRegistrert: 13 },
+                amplitude: { ...providerProps.amplitude, ukerRegistrert: 13 },
             }),
         });
-        expect(container).toBeEmptyDOMElement();
+        expect(container).not.toBeEmptyDOMElement();
     });
 
     test('komponenten vises IKKE når eksperimentet onboarding14a ikke er med', () => {

--- a/src/komponenter/14a-intro/14a.tsx
+++ b/src/komponenter/14a-intro/14a.tsx
@@ -151,8 +151,18 @@ function Sluttkort(props: EndStateProps) {
     const { amplitudeData, registreringData } = props;
     const { ukerRegistrert } = amplitudeData;
     const registrertDato = registreringData?.registrering?.opprettetDato;
-    const kortTittel =
-        ukerRegistrert > 12 ? 'Ta kontakt med en veileder' : 'Om du ønsker oppfølging før 12 uker må du gi oss beskjed';
+    const registrertOver12Uker = ukerRegistrert > 12;
+    const kortTittel = registrertOver12Uker
+        ? 'Ta kontakt med en veileder'
+        : 'Om du ønsker oppfølging før 12 uker må du gi oss beskjed';
+
+    const VeiledersOppgaver = () => {
+        return (
+            <Normaltekst>
+                Veilederen kan besvare spørsmål, bistå rundt det å søke stillinger og tilby hjelp på veien til arbeid.
+            </Normaltekst>
+        );
+    };
 
     const handleKlikkLesIntro = () => {
         amplitudeLogger('veientilarbeid.intro', {
@@ -176,12 +186,15 @@ function Sluttkort(props: EndStateProps) {
             <RegistrertTeller ukerRegistrert={ukerRegistrert} registrertDato={registrertDato} />
 
             <Lenkepanel14A amplitudeData={amplitudeData} href={''} antallUlesteDialoger={props.antallUlesteDialoger} />
-
-            <Normaltekst>
-                <Lenke className={'tracking-wide'} href={''} onClick={handleLesIntroPaaNytt}>
-                    Les om hva slags hjelp du kan få
-                </Lenke>
-            </Normaltekst>
+            {registrertOver12Uker ? (
+                <VeiledersOppgaver />
+            ) : (
+                <Normaltekst>
+                    <Lenke className={'tracking-wide'} href={''} onClick={handleLesIntroPaaNytt}>
+                        Les om hva slags hjelp du kan få
+                    </Lenke>
+                </Normaltekst>
+            )}
         </div>
     );
 }

--- a/src/komponenter/14a-intro/14a.tsx
+++ b/src/komponenter/14a-intro/14a.tsx
@@ -36,7 +36,36 @@ const ordenstall = {
     10: 'ellevte',
     11: 'tolvte',
     12: 'trettende',
+    13: 'fjortende',
+    14: 'femtende',
+    15: 'sekstende',
+    16: 'syttende',
+    17: 'attende',
+    18: 'nittende',
+    19: 'tjuende',
+    20: 'tjueførste',
+    21: 'tjueandre',
+    22: 'tjuetredje',
+    23: 'tjuefjerde',
+    24: 'tjuefemte',
 };
+
+interface TellerProps {
+    ukerRegistrert: number | 'INGEN_DATO';
+    registrertDato: string | undefined;
+}
+
+function RegistrertTeller({ ukerRegistrert, registrertDato }: TellerProps) {
+    const over23Uker = ukerRegistrert > 23;
+    let setning = '';
+    if (!over23Uker) {
+        setning = `Du er inne i din ${ordenstall[ukerRegistrert]} uke som registrert arbeidssøker.`;
+    }
+    if (over23Uker && registrertDato) {
+        setning = `Du har vært registrert arbeidssøker siden ${registrertDato}`;
+    }
+    return <Normaltekst className={'blokk-xs'}>{setning}</Normaltekst>;
+}
 
 function Kort1() {
     return (
@@ -157,13 +186,15 @@ function Kort4() {
 
 interface EndStateProps {
     amplitudeData: AmplitudeData;
+    registreringData: Brukerregistrering.Data | null;
     lesIntroPaaNyttCB: () => void;
     antallUlesteDialoger: number;
 }
 
 function Sluttkort(props: EndStateProps) {
-    const { amplitudeData } = props;
+    const { amplitudeData, registreringData } = props;
     const { ukerRegistrert } = amplitudeData;
+    const registrertDato = registreringData?.registrering?.opprettetDato;
 
     const handleKlikkLesIntro = () => {
         amplitudeLogger('veientilarbeid.intro', {
@@ -184,9 +215,7 @@ function Sluttkort(props: EndStateProps) {
         <div className={'sluttkort'}>
             <Element tag={'h1'}>OPPFØLGING</Element>
             <Systemtittel className={'blokk-xs'}>Om du ønsker oppfølging før 12 uker må du gi oss beskjed</Systemtittel>
-            <Normaltekst className={'blokk-xs'}>
-                Du er inne i din {ordenstall[ukerRegistrert]} uke som registrert arbeidssøker.
-            </Normaltekst>
+            <RegistrertTeller ukerRegistrert={ukerRegistrert} registrertDato={registrertDato} />
 
             <Lenkepanel14A amplitudeData={amplitudeData} href={''} antallUlesteDialoger={props.antallUlesteDialoger} />
 
@@ -399,6 +428,7 @@ function Intro14AWrapper() {
                     ) : (
                         <Sluttkort
                             amplitudeData={amplitudeData}
+                            registreringData={registreringData}
                             lesIntroPaaNyttCB={lesIntroPaaNyttCB}
                             antallUlesteDialoger={ulesteDialoger.antallUleste}
                         />
@@ -415,6 +445,7 @@ function Intro14AWrapper() {
                     <div className={'overall-wrapper'}>
                         <Sluttkort
                             amplitudeData={amplitudeData}
+                            registreringData={registreringData}
                             lesIntroPaaNyttCB={lesIntroPaaNyttCB}
                             antallUlesteDialoger={ulesteDialoger.antallUleste}
                         />

--- a/src/komponenter/14a-intro/14a.tsx
+++ b/src/komponenter/14a-intro/14a.tsx
@@ -151,6 +151,8 @@ function Sluttkort(props: EndStateProps) {
     const { amplitudeData, registreringData } = props;
     const { ukerRegistrert } = amplitudeData;
     const registrertDato = registreringData?.registrering?.opprettetDato;
+    const kortTittel =
+        ukerRegistrert > 12 ? 'Ta kontakt med en veileder' : 'Om du ønsker oppfølging før 12 uker må du gi oss beskjed';
 
     const handleKlikkLesIntro = () => {
         amplitudeLogger('veientilarbeid.intro', {
@@ -170,7 +172,7 @@ function Sluttkort(props: EndStateProps) {
     return (
         <div className={'sluttkort'}>
             <Element tag={'h1'}>OPPFØLGING</Element>
-            <Systemtittel className={'blokk-xs'}>Om du ønsker oppfølging før 12 uker må du gi oss beskjed</Systemtittel>
+            <Systemtittel className={'blokk-xs'}>{kortTittel}</Systemtittel>
             <RegistrertTeller ukerRegistrert={ukerRegistrert} registrertDato={registrertDato} />
 
             <Lenkepanel14A amplitudeData={amplitudeData} href={''} antallUlesteDialoger={props.antallUlesteDialoger} />

--- a/src/komponenter/14a-intro/14a.tsx
+++ b/src/komponenter/14a-intro/14a.tsx
@@ -19,53 +19,9 @@ import Lenke from 'nav-frontend-lenker';
 import PreState from '../meldekortintro/pre-state';
 import { UlesteDialogerContext } from '../../ducks/ulestedialoger';
 import ModalWrapper from 'nav-frontend-modal';
+import RegistrertTeller from './registrert-teller';
 
 const INTRO_KEY_14A = '14a-intro';
-
-const ordenstall = {
-    0: 'første',
-    1: 'andre',
-    2: 'tredje',
-    3: 'fjerde',
-    4: 'femte',
-    5: 'sjette',
-    6: 'sjuende',
-    7: 'åttende',
-    8: 'niende',
-    9: 'tiende',
-    10: 'ellevte',
-    11: 'tolvte',
-    12: 'trettende',
-    13: 'fjortende',
-    14: 'femtende',
-    15: 'sekstende',
-    16: 'syttende',
-    17: 'attende',
-    18: 'nittende',
-    19: 'tjuende',
-    20: 'tjueførste',
-    21: 'tjueandre',
-    22: 'tjuetredje',
-    23: 'tjuefjerde',
-    24: 'tjuefemte',
-};
-
-interface TellerProps {
-    ukerRegistrert: number | 'INGEN_DATO';
-    registrertDato: string | undefined;
-}
-
-function RegistrertTeller({ ukerRegistrert, registrertDato }: TellerProps) {
-    const over23Uker = ukerRegistrert > 23;
-    let setning = '';
-    if (!over23Uker) {
-        setning = `Du er inne i din ${ordenstall[ukerRegistrert]} uke som registrert arbeidssøker.`;
-    }
-    if (over23Uker && registrertDato) {
-        setning = `Du har vært registrert arbeidssøker siden ${registrertDato}`;
-    }
-    return <Normaltekst className={'blokk-xs'}>{setning}</Normaltekst>;
-}
 
 function Kort1() {
     return (

--- a/src/komponenter/14a-intro/14a.tsx
+++ b/src/komponenter/14a-intro/14a.tsx
@@ -310,11 +310,9 @@ export function kanVise14AStatus({
     const erAAP = brukerInfoData.rettighetsgruppe === 'AAP';
     const brukerregistreringData = registreringData?.registrering ?? null;
 
-    const registrertUnder12Uker = amplitudeData.ukerRegistrert < 12;
     const aldersgruppeUtenForsterketInnsats = brukerInfoData.alder >= 30 && brukerInfoData.alder <= 55;
 
     return (
-        registrertUnder12Uker &&
         aldersgruppeUtenForsterketInnsats &&
         !erAAP &&
         skalSeEksperiment &&

--- a/src/komponenter/14a-intro/14a.tsx
+++ b/src/komponenter/14a-intro/14a.tsx
@@ -14,7 +14,7 @@ import { fjernFraBrowserStorage, hentFraBrowserStorage, settIBrowserStorage } fr
 import ErRendret from '../er-rendret/er-rendret';
 import Feedback from '../feedback/feedback';
 import Lenkepanel14A from './lenkepanel-14a';
-import { FeaturetoggleContext } from '../../ducks/feature-toggles';
+import { FeaturetoggleContext, Data as FeaturetoggleData } from '../../ducks/feature-toggles';
 import Lenke from 'nav-frontend-lenker';
 import PreState from '../meldekortintro/pre-state';
 import { UlesteDialogerContext } from '../../ducks/ulestedialoger';
@@ -300,19 +300,23 @@ export function kanVise14AStatus({
     oppfolgingData,
     registreringData,
     amplitudeData,
+    featuretoggleData,
 }: {
     brukerInfoData: BrukerInfo.Data;
     oppfolgingData: Oppfolging.Data;
     registreringData: Brukerregistrering.Data | null;
     amplitudeData: AmplitudeData;
+    featuretoggleData: FeaturetoggleData;
 }): boolean {
     const skalSeEksperiment = amplitudeData.eksperimenter.includes('onboarding14a');
     const erAAP = brukerInfoData.rettighetsgruppe === 'AAP';
     const brukerregistreringData = registreringData?.registrering ?? null;
+    const featuretoggleAktivert = featuretoggleData && featuretoggleData['veientilarbeid.14a-intro'];
 
     const aldersgruppeUtenForsterketInnsats = brukerInfoData.alder >= 30 && brukerInfoData.alder <= 55;
 
     return (
+        featuretoggleAktivert &&
         aldersgruppeUtenForsterketInnsats &&
         !erAAP &&
         skalSeEksperiment &&
@@ -344,10 +348,14 @@ function Intro14AWrapper() {
         }
     }, [harSettIntro]);
 
-    const featuretoggleAktivert = featuretoggleData['veientilarbeid.14a-intro'];
     const modalToggle = featuretoggleData['veientilarbeid.modal'];
-    const kanViseKomponent =
-        featuretoggleAktivert && kanVise14AStatus({ amplitudeData, oppfolgingData, brukerInfoData, registreringData });
+    const kanViseKomponent = kanVise14AStatus({
+        amplitudeData,
+        featuretoggleData,
+        oppfolgingData,
+        brukerInfoData,
+        registreringData,
+    });
 
     if (!kanViseKomponent) {
         fjernFraBrowserStorage(INTRO_KEY_14A);

--- a/src/komponenter/14a-intro/registrert-teller.test.tsx
+++ b/src/komponenter/14a-intro/registrert-teller.test.tsx
@@ -17,7 +17,7 @@ describe('Tester komponenten RegistrertTeller', () => {
 
     test('Komponenten rendres med dato dersom man er i uke 24', () => {
         render(<RegistrertTeller ukerRegistrert={24} registrertDato="2021-06-01" />);
-        expect(screen.getByText(/2021-06-01/)).toBeInTheDocument();
+        expect(screen.getByText(/1. juni/)).toBeInTheDocument();
     });
 
     test('Komponenten rendres IKKE med dato dersom man er i uke 24 og dato er undefined', () => {

--- a/src/komponenter/14a-intro/registrert-teller.test.tsx
+++ b/src/komponenter/14a-intro/registrert-teller.test.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+
+import RegistrertTeller from './registrert-teller';
+
+describe('Tester komponenten RegistrertTeller', () => {
+    test('Komponenten rendres med første uke dersom man er i uke 0', () => {
+        render(<RegistrertTeller ukerRegistrert={0} registrertDato={undefined} />);
+        expect(screen.getByText(/første uke/)).toBeInTheDocument();
+    });
+
+    test('Komponenten rendres med tjuefjerde uke dersom man er i uke 23', () => {
+        render(<RegistrertTeller ukerRegistrert={23} registrertDato={undefined} />);
+        expect(screen.getByText(/tjuefjerde/)).toBeInTheDocument();
+    });
+
+    test('Komponenten rendres med dato dersom man er i uke 24', () => {
+        render(<RegistrertTeller ukerRegistrert={24} registrertDato="2021-06-01" />);
+        expect(screen.getByText(/2021-06-01/)).toBeInTheDocument();
+    });
+
+    test('Komponenten rendres IKKE med dato dersom man er i uke 24 og dato er undefined', () => {
+        const { container } = render(<RegistrertTeller ukerRegistrert={24} registrertDato={undefined} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+});

--- a/src/komponenter/14a-intro/registrert-teller.tsx
+++ b/src/komponenter/14a-intro/registrert-teller.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Normaltekst } from 'nav-frontend-typografi';
 
 interface TellerProps {
@@ -42,6 +42,8 @@ function RegistrertTeller({ ukerRegistrert, registrertDato }: TellerProps) {
     if (over23Uker && registrertDato) {
         setning = `Du har vært registrert arbeidssøker siden ${registrertDato}`;
     }
+    if (setning === '') return null;
+
     return <Normaltekst className={'blokk-xs'}>{setning}</Normaltekst>;
 }
 

--- a/src/komponenter/14a-intro/registrert-teller.tsx
+++ b/src/komponenter/14a-intro/registrert-teller.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Normaltekst } from 'nav-frontend-typografi';
+
+interface TellerProps {
+    ukerRegistrert: number | 'INGEN_DATO';
+    registrertDato: string | undefined;
+}
+
+function RegistrertTeller({ ukerRegistrert, registrertDato }: TellerProps) {
+    const ordenstall = {
+        0: 'første',
+        1: 'andre',
+        2: 'tredje',
+        3: 'fjerde',
+        4: 'femte',
+        5: 'sjette',
+        6: 'sjuende',
+        7: 'åttende',
+        8: 'niende',
+        9: 'tiende',
+        10: 'ellevte',
+        11: 'tolvte',
+        12: 'trettende',
+        13: 'fjortende',
+        14: 'femtende',
+        15: 'sekstende',
+        16: 'syttende',
+        17: 'attende',
+        18: 'nittende',
+        19: 'tjuende',
+        20: 'tjueførste',
+        21: 'tjueandre',
+        22: 'tjuetredje',
+        23: 'tjuefjerde',
+        24: 'tjuefemte',
+    };
+    const over23Uker = ukerRegistrert > 23;
+    let setning = '';
+    if (!over23Uker) {
+        setning = `Du er inne i din ${ordenstall[ukerRegistrert]} uke som registrert arbeidssøker.`;
+    }
+    if (over23Uker && registrertDato) {
+        setning = `Du har vært registrert arbeidssøker siden ${registrertDato}`;
+    }
+    return <Normaltekst className={'blokk-xs'}>{setning}</Normaltekst>;
+}
+
+export default RegistrertTeller;

--- a/src/komponenter/14a-intro/registrert-teller.tsx
+++ b/src/komponenter/14a-intro/registrert-teller.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Normaltekst } from 'nav-frontend-typografi';
 
+import prettyPrintDato from '../../utils/pretty-print-dato';
+
 interface TellerProps {
     ukerRegistrert: number | 'INGEN_DATO';
     registrertDato: string | undefined;
@@ -40,7 +42,7 @@ function RegistrertTeller({ ukerRegistrert, registrertDato }: TellerProps) {
         setning = `Du er inne i din ${ordenstall[ukerRegistrert]} uke som registrert arbeidssøker.`;
     }
     if (over23Uker && registrertDato) {
-        setning = `Du har vært registrert arbeidssøker siden ${registrertDato}`;
+        setning = `Du har vært registrert arbeidssøker siden ${prettyPrintDato(registrertDato)}`;
     }
     if (setning === '') return null;
 

--- a/src/komponenter/dagpenger-status/dagpenger-status.test.tsx
+++ b/src/komponenter/dagpenger-status/dagpenger-status.test.tsx
@@ -47,7 +47,7 @@ describe('Tester dagpengerkomponenten', () => {
         const { container } = render(<DagpengerStatus />, {
             wrapper: contextProviders({
                 ...providerProps,
-                featureToggle: { 'veientilarbeid.dagpenger-status': true },
+                featureToggle: { 'veientilarbeid.dagpenger-status': true, 'veientilarbeid.14a-intro': true },
             }),
         });
 
@@ -89,7 +89,10 @@ describe('Tester dagpengerkomponenten', () => {
                         opprettetDato: '2021-06-26',
                     },
                 },
-                featureToggle: { 'veientilarbeid.dpstatus-for-alle': true },
+                featureToggle: {
+                    'veientilarbeid.dpstatus-for-alle': true,
+                    'veientilarbeid.14a-intro': true,
+                },
             }),
         });
 
@@ -100,7 +103,7 @@ describe('Tester dagpengerkomponenten', () => {
         render(<DagpengerStatus />, {
             wrapper: contextProviders({
                 ...providerProps,
-                featureToggle: { 'veientilarbeid.dagpenger-status': true },
+                featureToggle: { 'veientilarbeid.dagpenger-status': true, 'veientilarbeid.14a-intro': true },
             }),
         });
 
@@ -115,7 +118,7 @@ describe('Tester dagpengerkomponenten', () => {
                     ...providerProps.brukerInfo,
                     rettighetsgruppe: 'DAGP',
                 },
-                featureToggle: { 'veientilarbeid.dagpenger-status': true },
+                featureToggle: { 'veientilarbeid.dagpenger-status': true, 'veientilarbeid.14a-intro': true },
             }),
         });
 
@@ -126,7 +129,7 @@ describe('Tester dagpengerkomponenten', () => {
         render(<DagpengerStatus />, {
             wrapper: contextProviders({
                 ...providerProps,
-                featureToggle: { 'veientilarbeid.dagpenger-status': true },
+                featureToggle: { 'veientilarbeid.dagpenger-status': true, 'veientilarbeid.14a-intro': true },
                 paabegynteSoknader: {
                     soknader: [
                         {
@@ -149,7 +152,7 @@ describe('Tester dagpengerkomponenten', () => {
         render(<DagpengerStatus />, {
             wrapper: contextProviders({
                 ...providerProps,
-                featureToggle: { 'veientilarbeid.dagpenger-status': true },
+                featureToggle: { 'veientilarbeid.dagpenger-status': true, 'veientilarbeid.14a-intro': true },
                 sakstema: {
                     sakstema: [
                         {
@@ -216,7 +219,7 @@ describe('Tester dagpengerkomponenten', () => {
         render(<DagpengerStatus />, {
             wrapper: contextProviders({
                 ...providerProps,
-                featureToggle: { 'veientilarbeid.dagpenger-status': true },
+                featureToggle: { 'veientilarbeid.dagpenger-status': true, 'veientilarbeid.14a-intro': true },
                 sakstema: {
                     sakstema: [
                         {

--- a/src/komponenter/dagpenger-status/dagpenger-status.tsx
+++ b/src/komponenter/dagpenger-status/dagpenger-status.tsx
@@ -73,7 +73,7 @@ function DagpengerStatus() {
 
     const kanViseKomponent =
         (featuretoggleDagpengerStatusAktivert &&
-            kanVise14AStatus({ amplitudeData, oppfolgingData, brukerInfoData, registreringData })) ||
+            kanVise14AStatus({ amplitudeData, featuretoggleData, oppfolgingData, brukerInfoData, registreringData })) ||
         (featuretoggleDPStatusForAlleAktivert &&
             kanViseDpStatus({ amplitudeData, oppfolgingData, brukerInfoData, registreringData }));
 

--- a/src/komponenter/dialog/dialog.tsx
+++ b/src/komponenter/dialog/dialog.tsx
@@ -10,6 +10,7 @@ import tekster from '../../tekster/tekster';
 import { AmplitudeContext } from '../../ducks/amplitude-context';
 import { UlesteDialogerContext } from '../../ducks/ulestedialoger';
 import { UnderOppfolgingContext } from '../../ducks/under-oppfolging';
+import { FeaturetoggleContext } from '../../ducks/feature-toggles';
 import * as BrukerInfo from '../../ducks/bruker-info';
 import { OppfolgingContext } from '../../ducks/oppfolging';
 import * as Brukerregistrering from '../../ducks/brukerregistrering';
@@ -18,11 +19,18 @@ import { kanVise14AStatus } from '../14a-intro/14a';
 const Dialog = () => {
     const amplitudeData = React.useContext(AmplitudeContext);
     const ulesteDialoger = React.useContext(UlesteDialogerContext).data;
+    const { data: featuretoggleData } = React.useContext(FeaturetoggleContext);
     const { underOppfolging } = React.useContext(UnderOppfolgingContext).data;
     const { data: registreringData } = React.useContext(Brukerregistrering.BrukerregistreringContext);
     const { data: oppfolgingData } = React.useContext(OppfolgingContext);
     const { data: brukerInfoData } = React.useContext(BrukerInfo.BrukerInfoContext);
-    const ser14aStatus = kanVise14AStatus({ amplitudeData, oppfolgingData, brukerInfoData, registreringData });
+    const ser14aStatus = kanVise14AStatus({
+        amplitudeData,
+        featuretoggleData,
+        oppfolgingData,
+        brukerInfoData,
+        registreringData,
+    });
 
     const kanViseKomponent = underOppfolging && !ser14aStatus;
 


### PR DESCRIPTION
Lar onboarding av 14a leve videre etter 12 uker.
- Oppdaterer sluttkortet til å ha et litt annet budskap etter 12 uker.
- legger inn featuretoggle som en del av kanVise14a funksjonen 