### PR TITLE
Lar noen arbeidssøkere registrerer dato for siste dag med lønn

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - ledig-fra-dato-bruk
+
 env:
   IMAGE_BASE: ghcr.io/${{github.repository}}/veientilarbeid
 
@@ -33,7 +33,7 @@ jobs:
           docker push ${IMAGE}
 
   deploy-dev:
-    if: github.ref == 'refs/heads/ledig-fra-dato-bruk'
+    if: github.ref == 'refs/heads/main'
     name: Deploy til dev
     needs: test-build-and-push
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ledig-fra-dato-bruk
 env:
   IMAGE_BASE: ghcr.io/${{github.repository}}/veientilarbeid
 
@@ -32,7 +33,7 @@ jobs:
           docker push ${IMAGE}
 
   deploy-dev:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/ledig-fra-dato-bruk'
     name: Deploy til dev
     needs: test-build-and-push
     runs-on: ubuntu-latest

--- a/src/demo/demo-state.ts
+++ b/src/demo/demo-state.ts
@@ -37,6 +37,7 @@ export enum DemoData {
     ER_UNDER_30 = 'erUnder30',
     SPRAK = 'lang',
     VIS_ARBEIDSLEDIG_DATO = 'visArbeidsledigDato',
+    GJELDER_FRA_DATO = 'gjelderFraDato',
 }
 
 export const hentDemoState = (key: string): string | null => hentQueryParam(key);
@@ -63,6 +64,9 @@ export const settRegistreringType = (value: string) => settDemoState(DemoData.RE
 
 export const hentGeografiskTilknytning = () => hentDemoState(DemoData.GEOGRAFISK_TILKNYTNING) || '3808';
 export const settGeografiskTilknytning = (value: string) => settDemoState(DemoData.GEOGRAFISK_TILKNYTNING, value);
+
+export const hentGjelderFraDato = () => hentDemoState(DemoData.GJELDER_FRA_DATO) || null;
+export const settGjelderFraDato = (value: string) => settDemoState(DemoData.GJELDER_FRA_DATO, value);
 
 export const hentUlesteDialoger = () => hentDemoState(DemoData.ULESTE_DIALOGER) === 'true';
 export const settUlesteDialoger = (value: boolean) => settDemoState(DemoData.ULESTE_DIALOGER, value);

--- a/src/demo/setup-demo-mock.ts
+++ b/src/demo/setup-demo-mock.ts
@@ -36,13 +36,19 @@ import {
     hentDpInnsynVedtak,
     hentDpInnsynSoknad,
     hentDpInnsynPaabegynte,
+    hentGjelderFraDato,
+    settGjelderFraDato,
 } from './demo-state';
 
 import { hentBrukerRegistrering } from './demo-state-brukerregistrering';
 import { AUTH_API } from '../komponenter/hent-initial-data/autentiseringsInfoFetcher';
-import msw_get, { msw_post } from '../mocks/msw-utils';
+import msw_get from '../mocks/msw-utils';
 import meldekortstatusResponse from '../mocks/meldekortstatus-mock';
-import gjelderFraResponse from '../mocks/gjelder-fra-mock';
+import { rest, RestRequest } from 'msw';
+
+interface GjelderFraBody {
+    dato: string;
+}
 
 export const demo_handlers = [
     msw_get(VEILARBOPPFOLGING_URL, {
@@ -89,6 +95,11 @@ export const demo_handlers = [
 
     msw_get(SAKSTEMA_URL, hentDpSakstema()),
 
-    msw_get(GJELDER_FRA_DATO_URL, gjelderFraResponse),
-    msw_post(GJELDER_FRA_DATO_URL, null, 204),
+    msw_get(GJELDER_FRA_DATO_URL, { dato: hentGjelderFraDato() }),
+    rest.post(GJELDER_FRA_DATO_URL, (req: RestRequest<GjelderFraBody>, res, ctx) => {
+        const { dato } = req.body;
+        settGjelderFraDato(dato);
+        window.location.reload();
+        return res(ctx.status(204));
+    }),
 ];

--- a/src/ducks/api.ts
+++ b/src/ducks/api.ts
@@ -50,4 +50,4 @@ export const BAKVEIEN = `${bakveienTilArbeidUrl}`,
     NESTE_MELDEKORT_URL = `${BAKVEIEN}/meldekort`,
     MELDEKORTSTATUS_URL = `${BAKVEIEN}/meldekort/status`,
     ARBEIDSSOKERPERIODER_URL = `${BAKVEIEN}/arbeidssoker/perioder?fraOgMed=2020-01-01`,
-    GJELDER_FRA_DATO_URL = `${BAKVEIEN}/gjelder-fra`;
+    GJELDER_FRA_DATO_URL = `${BAKVEIEN}/gjelderfra`;

--- a/src/ducks/api.ts
+++ b/src/ducks/api.ts
@@ -1,5 +1,6 @@
-import { contextpathDittNav, erMikrofrontend } from '../utils/app-state-utils';
 import { nanoid } from 'nanoid';
+
+import { contextpathDittNav, erMikrofrontend } from '../utils/app-state-utils';
 import { bakveienTilArbeidUrl } from './urls';
 
 export enum STATUS {
@@ -49,4 +50,4 @@ export const BAKVEIEN = `${bakveienTilArbeidUrl}`,
     NESTE_MELDEKORT_URL = `${BAKVEIEN}/meldekort`,
     MELDEKORTSTATUS_URL = `${BAKVEIEN}/meldekort/status`,
     ARBEIDSSOKERPERIODER_URL = `${BAKVEIEN}/arbeidssoker/perioder?fraOgMed=2020-01-01`,
-    GJELDER_FRA_DATO_URL = `${BAKVEIEN}/registrering/gjelder-fra`;
+    GJELDER_FRA_DATO_URL = `${BAKVEIEN}/gjelder-fra`;

--- a/src/ducks/api.ts
+++ b/src/ducks/api.ts
@@ -49,4 +49,4 @@ export const BAKVEIEN = `${bakveienTilArbeidUrl}`,
     NESTE_MELDEKORT_URL = `${BAKVEIEN}/meldekort`,
     MELDEKORTSTATUS_URL = `${BAKVEIEN}/meldekort/status`,
     ARBEIDSSOKERPERIODER_URL = `${BAKVEIEN}/arbeidssoker/perioder?fraOgMed=2020-01-01`,
-    GJELDER_FRA_DATO_URL = `${contextpath}/veilarbregistrering/api/registrering/gjelder-fra`;
+    GJELDER_FRA_DATO_URL = `${BAKVEIEN}/registrering/gjelder-fra`;

--- a/src/index.css
+++ b/src/index.css
@@ -26,6 +26,10 @@ html {
     bottom: 0;
 }
 
+.my-1 {
+    margin-top: -1rem;
+}
+
 .mr-05 {
     margin-right: 0.5rem;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,10 @@ html {
     margin-right: 0.5rem;
 }
 
+.ml-05 {
+    margin-left: 0.5rem;
+}
+
 .mb-1 {
     margin-bottom: 1rem;
 }

--- a/src/komponenter/arbeidsledig-dato/ArbeidsledigDato.tsx
+++ b/src/komponenter/arbeidsledig-dato/ArbeidsledigDato.tsx
@@ -10,8 +10,6 @@ import { plussDager } from '../../utils/date-utils';
 import { loggAktivitet } from '../../metrics/metrics';
 import { useAmplitudeData } from '../../contexts/amplitude-context';
 
-// TODO - legg inn amplitudedata
-
 function ArbeidsledigDato(): JSX.Element | null {
     const amplitudeData = useAmplitudeData();
     const { visModal, settLukkModal } = useArbeidsledigDato();
@@ -46,8 +44,8 @@ function ArbeidsledigDato(): JSX.Element | null {
                 method: 'POST',
                 body: JSON.stringify({ dato: gjelderFraDato }),
             });
-        } catch (err) {
-            console.error(err);
+        } catch (error) {
+            console.error(error);
         } finally {
             settLagrerDato(false);
             settLukkModal();
@@ -85,8 +83,12 @@ function ArbeidsledigDato(): JSX.Element | null {
                 <BodyShort spacing={true}>
                     <Link
                         href={'#'}
-                        onClick={(e) => {
-                            e.preventDefault();
+                        onClick={(event) => {
+                            event.preventDefault();
+                            loggAktivitet({
+                                aktivitet: 'Ønsker ikke oppgi dato for siste dag med lønn',
+                                ...amplitudeData,
+                            });
                             settLukkModal();
                         }}
                     >

--- a/src/komponenter/arbeidsledig-dato/ArbeidsledigDato.tsx
+++ b/src/komponenter/arbeidsledig-dato/ArbeidsledigDato.tsx
@@ -45,6 +45,7 @@ function ArbeidsledigDato(): JSX.Element | null {
         } finally {
             settLagrerDato(false);
             settLukkModal();
+            //TODO: Sjekke hvordan vi oppdaterer parentkomponenten når dato blir endret
         }
     }, [gjelderFraDato, settLukkModal]);
 

--- a/src/komponenter/arbeidsledig-dato/ArbeidsledigDato.tsx
+++ b/src/komponenter/arbeidsledig-dato/ArbeidsledigDato.tsx
@@ -8,6 +8,8 @@ import { fetchToJson } from '../../ducks/api-utils';
 import { GJELDER_FRA_DATO_URL, requestConfig } from '../../ducks/api';
 import { plussDager } from '../../utils/date-utils';
 
+// TODO - legg inn amplitudedata
+
 function ArbeidsledigDato(): JSX.Element | null {
     const { visModal, settLukkModal } = useArbeidsledigDato();
     const featureToggleData = useFeatureToggleData();
@@ -60,7 +62,7 @@ function ArbeidsledigDato(): JSX.Element | null {
         <Modal open={visModal} onClose={settLukkModal} shouldCloseOnOverlayClick={false}>
             <Modal.Content>
                 <Heading spacing={true} size={'medium'} style={{ marginRight: '2em' }}>
-                    Når mistet du eller kommer du til å miste jobben?
+                    Hvilken dag er den siste dagen med lønn?
                 </Heading>
                 <BodyShort spacing={true}>
                     <input

--- a/src/komponenter/arbeidsledig-dato/ArbeidsledigDato.tsx
+++ b/src/komponenter/arbeidsledig-dato/ArbeidsledigDato.tsx
@@ -1,7 +1,9 @@
+import { useCallback, useEffect, useState } from 'react';
 import { BodyShort, Button, Heading, Link, Modal } from '@navikt/ds-react';
+
 import { useArbeidsledigDato } from '../../contexts/arbeidsledig-dato';
 import { useFeatureToggleData } from '../../contexts/feature-toggles';
-import { useCallback, useEffect, useState } from 'react';
+import { useBrukerregistreringData, DinSituasjonSvar } from '../../contexts/brukerregistrering';
 import { fetchToJson } from '../../ducks/api-utils';
 import { GJELDER_FRA_DATO_URL, requestConfig } from '../../ducks/api';
 import { plussDager } from '../../utils/date-utils';
@@ -9,8 +11,12 @@ import { plussDager } from '../../utils/date-utils';
 function ArbeidsledigDato(): JSX.Element | null {
     const { visModal, settLukkModal } = useArbeidsledigDato();
     const featureToggleData = useFeatureToggleData();
+    const registreringData = useBrukerregistreringData();
+    const brukerregistreringData = registreringData?.registrering ?? null;
+    const dinSituasjon = brukerregistreringData?.besvarelse.dinSituasjon || DinSituasjonSvar.INGEN_VERDI;
+    const harMistetJobben = dinSituasjon === DinSituasjonSvar.MISTET_JOBBEN;
 
-    const visKomponent = featureToggleData['veientilarbeid.vis-arbeidsledig-dato'];
+    const visKomponent = featureToggleData['veientilarbeid.vis-arbeidsledig-dato'] && harMistetJobben;
 
     const [gjelderFraDato, settGjelderFraDato] = useState<string | null>(null);
     const [lagrerDato, settLagrerDato] = useState<boolean>(false);

--- a/src/komponenter/arbeidsledig-dato/ArbeidsledigDato.tsx
+++ b/src/komponenter/arbeidsledig-dato/ArbeidsledigDato.tsx
@@ -7,10 +7,13 @@ import { useBrukerregistreringData, DinSituasjonSvar } from '../../contexts/bruk
 import { fetchToJson } from '../../ducks/api-utils';
 import { GJELDER_FRA_DATO_URL, requestConfig } from '../../ducks/api';
 import { plussDager } from '../../utils/date-utils';
+import { loggAktivitet } from '../../metrics/metrics';
+import { useAmplitudeData } from '../../contexts/amplitude-context';
 
 // TODO - legg inn amplitudedata
 
 function ArbeidsledigDato(): JSX.Element | null {
+    const amplitudeData = useAmplitudeData();
     const { visModal, settLukkModal } = useArbeidsledigDato();
     const featureToggleData = useFeatureToggleData();
     const registreringData = useBrukerregistreringData();
@@ -33,6 +36,9 @@ function ArbeidsledigDato(): JSX.Element | null {
     };
 
     const onSubmit = useCallback(async () => {
+        gjelderFraDato == null
+            ? loggAktivitet({ aktivitet: 'Setter dato for siste dag med lønn', ...amplitudeData })
+            : loggAktivitet({ aktivitet: 'Endrer dato for siste dag med lønn', ...amplitudeData });
         try {
             settLagrerDato(true);
             await fetchToJson(GJELDER_FRA_DATO_URL, {

--- a/src/komponenter/arbeidsledig-dato/ArbeidsledigDato.tsx
+++ b/src/komponenter/arbeidsledig-dato/ArbeidsledigDato.tsx
@@ -51,7 +51,7 @@ function ArbeidsledigDato(): JSX.Element | null {
             settLukkModal();
             //TODO: Sjekke hvordan vi oppdaterer parentkomponenten når dato blir endret
         }
-    }, [gjelderFraDato, settLukkModal]);
+    }, [gjelderFraDato, settLukkModal, amplitudeData]);
 
     useEffect(() => {
         if (visModal) {

--- a/src/komponenter/feedback/feedback.css
+++ b/src/komponenter/feedback/feedback.css
@@ -22,7 +22,7 @@
     cursor: pointer;
     padding-left: 0.5rem;
     padding-right: 0.5rem;
-    width: 4rem;
+    width: 4.5rem;
     text-align: center;
 }
 

--- a/src/komponenter/onboarding-standard/onboarding-standard-stegnummer.tsx
+++ b/src/komponenter/onboarding-standard/onboarding-standard-stegnummer.tsx
@@ -1,5 +1,5 @@
 import TallSirkel from '../tall/tall';
-import { skalViseOnboardingStandard } from '../../lib/skal-vise-onboarding-standard';
+import { erStandardTilknyttetArbeid } from '../../lib/er-standard-tilknyttet-arbeid';
 import { useBrukerregistreringData } from '../../contexts/brukerregistrering';
 import { useOppfolgingData } from '../../contexts/oppfolging';
 import { useFeatureToggleData } from '../../contexts/feature-toggles';
@@ -14,7 +14,7 @@ const OnboardingStandardStegnummer = (props: Props) => {
     const oppfolgingData = useOppfolgingData();
     const featuretoggleData = useFeatureToggleData();
 
-    const kanViseKomponent = skalViseOnboardingStandard({
+    const kanViseKomponent = erStandardTilknyttetArbeid({
         oppfolgingData,
         registreringData,
         featuretoggleData,

--- a/src/komponenter/onboarding-standard/onboarding-standard.tsx
+++ b/src/komponenter/onboarding-standard/onboarding-standard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Heading, Panel, BodyLong, Link } from '@navikt/ds-react';
+import { Heading, Panel, BodyLong, Link, BodyShort } from '@navikt/ds-react';
 
 import InViewport from '../in-viewport/in-viewport';
 import ErRendret from '../er-rendret/er-rendret';
@@ -17,6 +17,7 @@ import { hentFraBrowserStorage } from '../../utils/browserStorage-utils';
 import Feedback from '../feedback/feedback';
 import TallSirkel from '../tall/tall';
 import hentTekstnokkelForOnboardingTrinn1 from '../../lib/hent-tekstnokkel-for-onboarding-trinn1';
+import prettyPrintDato from '../../utils/pretty-print-dato';
 
 const TEKSTER = {
     nb: {
@@ -75,6 +76,35 @@ function beregnNesteTrinn(utforteTrinn: Number[]) {
     return nesteTrinn;
 }
 
+const LeggTilEllerEndreDato = ({
+    kanViseKomponent,
+    dato,
+}: {
+    kanViseKomponent: boolean | undefined;
+    dato: string | null;
+}) => {
+    const { settVisModal: settVisArbeidsledigDatoModal } = useArbeidsledigDato();
+    if (!kanViseKomponent) return null;
+    return (
+        <div className="flex blokk-xs my-1">
+            {dato && (
+                <BodyShort>
+                    Siste dag med lønn: <b>{prettyPrintDato(dato)}</b>&nbsp;
+                </BodyShort>
+            )}
+            <Link
+                href={'#'}
+                onClick={(e) => {
+                    e.preventDefault();
+                    settVisArbeidsledigDatoModal();
+                }}
+            >
+                {dato ? 'Endre dato' : ''}
+            </Link>
+        </div>
+    );
+};
+
 const OnboardingStandard = () => {
     const [gjelderFraDato, settGjelderFraDato] = useState<string | null>(null);
     const tekst = lagHentTekstForSprak(TEKSTER, useSprakValg().sprak);
@@ -121,6 +151,7 @@ const OnboardingStandard = () => {
                 <Heading size="medium" level="2" className="blokk-xs">
                     {tekst('header')}
                 </Heading>
+                <LeggTilEllerEndreDato kanViseKomponent={visArbeidsLedigDatoLenke} dato={gjelderFraDato} />
                 <BodyLong spacing className={`flex${utforteTrinn.includes(1) ? ' inaktiv' : ''}`}>
                     <TallSirkel tall={1} aktiv={nesteTrinn === 1} inaktiv={utforteTrinn.includes(1)} />{' '}
                     {tekst(hentTekstnokkelForOnboardingTrinn1(gjelderFraDato))}

--- a/src/komponenter/onboarding-standard/onboarding-standard.tsx
+++ b/src/komponenter/onboarding-standard/onboarding-standard.tsx
@@ -29,7 +29,7 @@ const TEKSTER = {
         trinn1Imorgen:
             'Du bør sende inn søknad om dagpenger i dag. Hvis du sender inn søknaden senere vil du få mindre i dagpenger på din første utbetaling',
         trinn1Fremtid:
-            'Du bør sende søknaden om dagpenger tidligst 10. juni og senest 20 juni. Det er lurt starte på søknaden allerede nå, sånn at du finner ut hvilke dokumenter du må få tak i.', // TODO: fiks datoer i teksten
+            'Du bør sende søknaden om dagpenger tidligst 10. juni og senest 20 juni. Det er lurt starte på søknaden allerede nå, sånn at du finner ut hvilke dokumenter du må få tak i', // TODO: fiks datoer i teksten
         trinn2: 'Les gjennom introduksjonen til meldekort',
         trinn3: 'Finn ut om du er enig i hvordan NAV har vurdert ditt behov for hjelp og støtte',
         feedbackSporsmal: 'Er denne oversikten nyttig?',

--- a/src/komponenter/onboarding-standard/onboarding-standard.tsx
+++ b/src/komponenter/onboarding-standard/onboarding-standard.tsx
@@ -94,12 +94,12 @@ const LeggTilEllerEndreDato = ({
             )}
             <Link
                 href={'#'}
-                onClick={(e) => {
-                    e.preventDefault();
+                onClick={(event) => {
+                    event.preventDefault();
                     settVisArbeidsledigDatoModal();
                 }}
             >
-                {dato ? 'Endre dato' : ''}
+                {dato ? 'Endre dato' : 'En lang tekst som sier noe lurt'}
             </Link>
         </div>
     );
@@ -112,7 +112,6 @@ const OnboardingStandard = () => {
     const oppfolgingData = useOppfolgingData();
     const featuretoggleData = useFeatureToggleData();
     const { dagpengestatus } = useAmplitudeData();
-    const { settVisModal: settVisArbeidsledigDatoModal } = useArbeidsledigDato();
     const brukerregistreringData = registreringData?.registrering ?? null;
     const dinSituasjon = brukerregistreringData?.besvarelse.dinSituasjon || DinSituasjonSvar.INGEN_VERDI;
     const harMistetJobben = dinSituasjon === DinSituasjonSvar.MISTET_JOBBEN;
@@ -166,17 +165,6 @@ const OnboardingStandard = () => {
                 </BodyLong>
                 <Feedback id="standard-onboarding-info" sporsmal={tekst('feedbackSporsmal')} />
                 <InViewport loggTekst="Viser OnboardingStandard i viewport" />
-                {visArbeidsLedigDatoLenke && (
-                    <Link
-                        href={'#'}
-                        onClick={(e) => {
-                            e.preventDefault();
-                            settVisArbeidsledigDatoModal();
-                        }}
-                    >
-                        Velg dato
-                    </Link>
-                )}
             </Panel>
         );
     return null;

--- a/src/komponenter/onboarding-standard/onboarding-standard.tsx
+++ b/src/komponenter/onboarding-standard/onboarding-standard.tsx
@@ -24,16 +24,16 @@ import { loggAktivitet } from '../../metrics/metrics';
 const TEKSTER = {
     nb: {
         header: 'Tre viktige ting i din første uke som registrert arbeidssøker',
-        trinn1: 'Start på en søknad om dagpenger i dag, slik at du finner ut når du må sende inn søknaden',
+        trinn1: 'Start på søknaden om dagpenger, slik at du finner ut når du må sende inn søknaden.',
         trinn1Fortid:
-            'Du bør sende inn søknad om dagpenger i dag. Om du mangler dokumentasjon, bør du heller ettersende disse senere. Det viktige nå er at du får sendt inn søknaden så raskt som mulig.',
+            'Du bør sende inn søknad om dagpenger i dag. Om du mangler dokumentasjon, bør du ettersende disse så snart du har fått tak i dokumentasjonen. Det viktige nå er at du får sendt inn søknaden så raskt som mulig.',
         trinn1Idag:
-            'Du bør sende inn søknad om dagpenger senest i morgen ({{datoSenest}}). Hvis du sender inn søknaden senere vil du få mindre i dagpenger på din første utbetaling',
+            'Du bør sende inn søknad om dagpenger senest i morgen, {{datoSenest}}. Hvis du sender inn søknaden senere vil du få mindre i dagpenger på din første utbetaling',
         trinn1Imorgen:
-            'Du bør sende inn søknad om dagpenger i dag. Hvis du sender inn søknaden senere vil du få mindre i dagpenger på din første utbetaling',
-        trinn1Fremtid: `Du bør sende søknaden om dagpenger tidligst {{datoTidligst}} og senest {{datoSenest}}. Det er lurt starte på søknaden allerede nå, sånn at du finner ut hvilke dokumenter du må få tak i`, // TODO: fiks datoer i teksten
-        trinn2: 'Les gjennom introduksjonen til meldekort',
-        trinn3: 'Finn ut om du er enig i hvordan NAV har vurdert ditt behov for hjelp og støtte',
+            'Du bør sende inn søknad om dagpenger i dag. Hvis du sender inn søknaden senere vil du få mindre i dagpenger på din første utbetaling.',
+        trinn1Fremtid: `Du bør sende søknaden om dagpenger tidligst {{datoTidligst}} og senest {{datoSenest}}. Det er lurt starte på søknaden allerede nå, sånn at du finner ut hvilke dokumenter du må få tak i`,
+        trinn2: 'Les gjennom introduksjonen til meldekort.',
+        trinn3: 'Finn ut om du er enig i hvordan NAV har vurdert ditt behov for hjelp og støtte.',
         feedbackSporsmal: 'Er denne oversikten nyttig?',
     },
     en: {

--- a/src/komponenter/onboarding-standard/onboarding-standard.tsx
+++ b/src/komponenter/onboarding-standard/onboarding-standard.tsx
@@ -26,12 +26,12 @@ const TEKSTER = {
         header: 'Tre viktige ting i din første uke som registrert arbeidssøker',
         trinn1: 'Start på søknaden om dagpenger, slik at du finner ut når du må sende inn søknaden.',
         trinn1Fortid:
-            'Du bør sende inn søknad om dagpenger i dag. Om du mangler dokumentasjon, bør du ettersende disse så snart du har fått tak i dokumentasjonen. Det viktige nå er at du får sendt inn søknaden så raskt som mulig.',
+            'Du bør sende inn søknad om dagpenger i dag.<br />Om du mangler dokumentasjon, bør du ettersende disse så snart du har fått tak i dokumentasjonen. Det viktige nå er at du får sendt inn søknaden så raskt som mulig.',
         trinn1Idag:
-            'Du bør sende inn søknad om dagpenger senest i morgen, {{datoSenest}}. Hvis du sender inn søknaden senere vil du få mindre i dagpenger på din første utbetaling',
+            'Du bør sende inn søknad om dagpenger senest i morgen, {{datoSenest}}.<br />Hvis du sender inn søknaden senere vil du få mindre i dagpenger på din første utbetaling.',
         trinn1Imorgen:
-            'Du bør sende inn søknad om dagpenger i dag. Hvis du sender inn søknaden senere vil du få mindre i dagpenger på din første utbetaling.',
-        trinn1Fremtid: `Du bør sende søknaden om dagpenger tidligst {{datoTidligst}} og senest {{datoSenest}}. Det er lurt starte på søknaden allerede nå, sånn at du finner ut hvilke dokumenter du må få tak i`,
+            'Du bør sende inn søknad om dagpenger i dag.<br />Hvis du sender inn søknaden senere vil du få mindre i dagpenger på din første utbetaling.',
+        trinn1Fremtid: `Du bør sende søknaden om dagpenger tidligst {{datoTidligst}} og senest {{datoSenest}}.<br />Det er lurt starte på søknaden allerede nå, sånn at du finner ut hvilke dokumenter du må få tak i.`,
         trinn2: 'Les gjennom introduksjonen til meldekort.',
         trinn3: 'Finn ut om du er enig i hvordan NAV har vurdert ditt behov for hjelp og støtte.',
         feedbackSporsmal: 'Er denne oversikten nyttig?',
@@ -176,9 +176,13 @@ const OnboardingStandard = () => {
                 <LeggTilEllerEndreDato kanViseKomponent={visArbeidsLedigDatoLenke} dato={gjelderFraDato} />
                 <BodyLong spacing className={`flex${utforteTrinn.includes(1) ? ' inaktiv' : ''}`}>
                     <TallSirkel tall={1} aktiv={nesteTrinn === 1} inaktiv={utforteTrinn.includes(1)} />{' '}
-                    {tekst(hentTekstnokkelForOnboardingTrinn1(gjelderFraDato))
-                        .replace('{{datoSenest}}', datoSenest)
-                        .replace('{{datoTidligst}}', datoTidligst)}
+                    <span
+                        dangerouslySetInnerHTML={{
+                            __html: tekst(hentTekstnokkelForOnboardingTrinn1(gjelderFraDato))
+                                .replace('{{datoSenest}}', datoSenest)
+                                .replace('{{datoTidligst}}', datoTidligst),
+                        }}
+                    ></span>
                 </BodyLong>
                 <BodyLong spacing className={`flex${utforteTrinn.includes(2) ? ' inaktiv' : ''}`}>
                     <TallSirkel tall={2} aktiv={nesteTrinn === 2} inaktiv={utforteTrinn.includes(2)} />{' '}

--- a/src/komponenter/onboarding-standard/onboarding-standard.tsx
+++ b/src/komponenter/onboarding-standard/onboarding-standard.tsx
@@ -19,6 +19,7 @@ import TallSirkel from '../tall/tall';
 import hentTekstnokkelForOnboardingTrinn1 from '../../lib/hent-tekstnokkel-for-onboarding-trinn1';
 import prettyPrintDato from '../../utils/pretty-print-dato';
 import { plussDager } from '../../utils/date-utils';
+import { loggAktivitet } from '../../metrics/metrics';
 
 const TEKSTER = {
     nb: {
@@ -84,6 +85,7 @@ const LeggTilEllerEndreDato = ({
     dato: string | null;
 }) => {
     const { settVisModal: settVisArbeidsledigDatoModal } = useArbeidsledigDato();
+    const amplitudeData = useAmplitudeData();
     if (!kanViseKomponent) return null;
     return (
         <div className="flex blokk-xs my-1">
@@ -97,6 +99,15 @@ const LeggTilEllerEndreDato = ({
                 href={'#'}
                 onClick={(event) => {
                     event.preventDefault();
+                    dato
+                        ? loggAktivitet({
+                              aktivitet: 'Arbeidssøker vil endre dato for siste dag med lønn',
+                              ...amplitudeData,
+                          })
+                        : loggAktivitet({
+                              aktivitet: 'Arbeidssøker vil registrere dato for siste dag med lønn',
+                              ...amplitudeData,
+                          });
                     settVisArbeidsledigDatoModal();
                 }}
             >

--- a/src/komponenter/onboarding-standard/onboarding-standard.tsx
+++ b/src/komponenter/onboarding-standard/onboarding-standard.tsx
@@ -18,6 +18,7 @@ import Feedback from '../feedback/feedback';
 import TallSirkel from '../tall/tall';
 import hentTekstnokkelForOnboardingTrinn1 from '../../lib/hent-tekstnokkel-for-onboarding-trinn1';
 import prettyPrintDato from '../../utils/pretty-print-dato';
+import { plussDager } from '../../utils/date-utils';
 
 const TEKSTER = {
     nb: {
@@ -26,11 +27,10 @@ const TEKSTER = {
         trinn1Fortid:
             'Du bør sende inn søknad om dagpenger i dag. Om du mangler dokumentasjon, bør du heller ettersende disse senere. Det viktige nå er at du får sendt inn søknaden så raskt som mulig.',
         trinn1Idag:
-            'Du bør sende inn søknad om dagpenger senest i morgen. Hvis du sender inn søknaden senere vil du få mindre i dagpenger på din første utbetaling',
+            'Du bør sende inn søknad om dagpenger senest i morgen ({{datoSenest}}). Hvis du sender inn søknaden senere vil du få mindre i dagpenger på din første utbetaling',
         trinn1Imorgen:
             'Du bør sende inn søknad om dagpenger i dag. Hvis du sender inn søknaden senere vil du få mindre i dagpenger på din første utbetaling',
-        trinn1Fremtid:
-            'Du bør sende søknaden om dagpenger tidligst 10. juni og senest 20 juni. Det er lurt starte på søknaden allerede nå, sånn at du finner ut hvilke dokumenter du må få tak i', // TODO: fiks datoer i teksten
+        trinn1Fremtid: `Du bør sende søknaden om dagpenger tidligst {{datoTidligst}} og senest {{datoSenest}}. Det er lurt starte på søknaden allerede nå, sånn at du finner ut hvilke dokumenter du må få tak i`, // TODO: fiks datoer i teksten
         trinn2: 'Les gjennom introduksjonen til meldekort',
         trinn3: 'Finn ut om du er enig i hvordan NAV har vurdert ditt behov for hjelp og støtte',
         feedbackSporsmal: 'Er denne oversikten nyttig?',
@@ -107,6 +107,8 @@ const LeggTilEllerEndreDato = ({
 
 const OnboardingStandard = () => {
     const [gjelderFraDato, settGjelderFraDato] = useState<string | null>(null);
+    const [datoTidligst, settDatoTidligst] = useState<string>('');
+    const [datoSenest, settDatoSenest] = useState<string>('');
     const tekst = lagHentTekstForSprak(TEKSTER, useSprakValg().sprak);
     const registreringData = useBrukerregistreringData();
     const oppfolgingData = useOppfolgingData();
@@ -143,6 +145,15 @@ const OnboardingStandard = () => {
         }
     }, [kanViseKomponent, visArbeidsLedigDatoLenke]);
 
+    useEffect(() => {
+        if (gjelderFraDato) {
+            const datoTidligst = prettyPrintDato(plussDager(new Date(gjelderFraDato), -7).toISOString());
+            const datoSenest = prettyPrintDato(plussDager(new Date(gjelderFraDato), 1).toISOString());
+            settDatoTidligst(datoTidligst);
+            settDatoSenest(datoSenest);
+        }
+    }, [gjelderFraDato]);
+
     if (kanViseKomponent)
         return (
             <Panel border className="ramme blokk-s" id="standard-onboarding">
@@ -153,7 +164,9 @@ const OnboardingStandard = () => {
                 <LeggTilEllerEndreDato kanViseKomponent={visArbeidsLedigDatoLenke} dato={gjelderFraDato} />
                 <BodyLong spacing className={`flex${utforteTrinn.includes(1) ? ' inaktiv' : ''}`}>
                     <TallSirkel tall={1} aktiv={nesteTrinn === 1} inaktiv={utforteTrinn.includes(1)} />{' '}
-                    {tekst(hentTekstnokkelForOnboardingTrinn1(gjelderFraDato))}
+                    {tekst(hentTekstnokkelForOnboardingTrinn1(gjelderFraDato))
+                        .replace('{{datoSenest}}', datoSenest)
+                        .replace('{{datoTidligst}}', datoTidligst)}
                 </BodyLong>
                 <BodyLong spacing className={`flex${utforteTrinn.includes(2) ? ' inaktiv' : ''}`}>
                     <TallSirkel tall={2} aktiv={nesteTrinn === 2} inaktiv={utforteTrinn.includes(2)} />{' '}

--- a/src/komponenter/onboarding-standard/onboarding-standard.tsx
+++ b/src/komponenter/onboarding-standard/onboarding-standard.tsx
@@ -5,7 +5,7 @@ import ErRendret from '../er-rendret/er-rendret';
 import lagHentTekstForSprak from '../../lib/lag-hent-tekst-for-sprak';
 import { useAmplitudeData } from '../../contexts/amplitude-context';
 import { useSprakValg } from '../../contexts/sprak';
-import { useBrukerregistreringData } from '../../contexts/brukerregistrering';
+import { useBrukerregistreringData, DinSituasjonSvar } from '../../contexts/brukerregistrering';
 import { useOppfolgingData } from '../../contexts/oppfolging';
 import { useFeatureToggleData } from '../../contexts/feature-toggles';
 import { skalViseOnboardingStandard } from '../../lib/skal-vise-onboarding-standard';
@@ -77,7 +77,10 @@ const OnboardingStandard = () => {
     const featuretoggleData = useFeatureToggleData();
     const { dagpengestatus } = useAmplitudeData();
     const { settVisModal: settVisArbeidsledigDatoModal } = useArbeidsledigDato();
-    const visArbeidsLedigDatoLenke = featuretoggleData['veientilarbeid.vis-arbeidsledig-dato'];
+    const brukerregistreringData = registreringData?.registrering ?? null;
+    const dinSituasjon = brukerregistreringData?.besvarelse.dinSituasjon || DinSituasjonSvar.INGEN_VERDI;
+    const harMistetJobben = dinSituasjon === DinSituasjonSvar.MISTET_JOBBEN;
+    const visArbeidsLedigDatoLenke = featuretoggleData['veientilarbeid.vis-arbeidsledig-dato'] && harMistetJobben;
 
     const kanViseKomponent = skalViseOnboardingStandard({
         oppfolgingData,

--- a/src/komponenter/onboarding-standard/onboarding-standard.tsx
+++ b/src/komponenter/onboarding-standard/onboarding-standard.tsx
@@ -89,9 +89,10 @@ const LeggTilEllerEndreDato = ({
         <div className="flex blokk-xs my-1">
             {dato && (
                 <BodyShort>
-                    Siste dag med lønn: <b>{prettyPrintDato(dato)}</b>&nbsp;
+                    Siste dag med lønn: <b>{prettyPrintDato(dato)}</b>
                 </BodyShort>
             )}
+            {dato && <div className="mr-05 ml-05">|</div>}
             <Link
                 href={'#'}
                 onClick={(event) => {
@@ -99,7 +100,7 @@ const LeggTilEllerEndreDato = ({
                     settVisArbeidsledigDatoModal();
                 }}
             >
-                {dato ? 'Endre dato' : 'En lang tekst som sier noe lurt'}
+                {dato ? 'Endre dato' : 'Trenger du veiledning om når du bør sende inn søknad om dagpenger?'}
             </Link>
         </div>
     );

--- a/src/lib/er-standard-tilknyttet-arbeid.ts
+++ b/src/lib/er-standard-tilknyttet-arbeid.ts
@@ -2,9 +2,8 @@ import { Data as FeaturetoggleData } from '../contexts/feature-toggles';
 import * as Brukerregistrering from '../contexts/brukerregistrering';
 import * as Oppfolging from '../contexts/oppfolging';
 import sjekkOmBrukerErStandardInnsatsgruppe from './er-standard-innsatsgruppe';
-import ukerFraDato from '../utils/uker-fra-dato';
 
-export function skalViseOnboardingStandard({
+export function erStandardTilknyttetArbeid({
     oppfolgingData,
     registreringData,
     featuretoggleData,
@@ -14,12 +13,6 @@ export function skalViseOnboardingStandard({
     featuretoggleData: FeaturetoggleData;
 }): boolean {
     const brukerregistreringData = registreringData?.registrering ?? null;
-
-    const opprettetRegistreringDatoString = brukerregistreringData?.opprettetDato;
-    const opprettetRegistreringDato = opprettetRegistreringDatoString
-        ? new Date(opprettetRegistreringDatoString)
-        : null;
-    const ukerRegistrert = opprettetRegistreringDato ? ukerFraDato(opprettetRegistreringDato) : 'INGEN_DATO';
     const dinSituasjon =
         brukerregistreringData?.besvarelse.dinSituasjon || Brukerregistrering.DinSituasjonSvar.INGEN_VERDI;
     const harRettSituasjon = [
@@ -31,5 +24,5 @@ export function skalViseOnboardingStandard({
     const visOnboardingStandardInformasjonToggle = featuretoggleData['veientilarbeid.vis-onboarding-standard'];
     const kanViseForStandard = erStandardInnsatsgruppe && visOnboardingStandardInformasjonToggle;
 
-    return kanViseForStandard && !oppfolgingData.kanReaktiveres && ukerRegistrert === 0 && harRettSituasjon;
+    return kanViseForStandard && !oppfolgingData.kanReaktiveres && harRettSituasjon;
 }

--- a/src/lib/hent-tekstnokkel-for-onboarding-trinn1.test.ts
+++ b/src/lib/hent-tekstnokkel-for-onboarding-trinn1.test.ts
@@ -7,14 +7,16 @@ describe('hentTestnokkelForOnboardingTrinn1', () => {
     });
 
     it('returnerer "trinn1-fortid" når dato er tilbake i tid', () => {
-        expect(hentTekstnokkelForOnboardingTrinn1(plussDager(new Date(), -10))).toBe('trinn1Fortid');
+        expect(hentTekstnokkelForOnboardingTrinn1(plussDager(new Date(), -10).toISOString())).toBe('trinn1Fortid');
     });
 
     it('returnerer "trinn1-idag" når dato er idag', () => {
-        expect(hentTekstnokkelForOnboardingTrinn1(datoUtenTid(new Date().toISOString()))).toBe('trinn1Idag');
+        expect(hentTekstnokkelForOnboardingTrinn1(datoUtenTid(new Date().toISOString()).toISOString())).toBe(
+            'trinn1Idag'
+        );
     });
 
     it('returnerer "trinn1-fremtid" når dato er frem i tid', () => {
-        expect(hentTekstnokkelForOnboardingTrinn1(plussDager(new Date(), 7))).toBe('trinn1Fremtid');
+        expect(hentTekstnokkelForOnboardingTrinn1(plussDager(new Date(), 7).toISOString())).toBe('trinn1Fremtid');
     });
 });

--- a/src/lib/hent-tekstnokkel-for-onboarding-trinn1.test.ts
+++ b/src/lib/hent-tekstnokkel-for-onboarding-trinn1.test.ts
@@ -10,6 +10,10 @@ describe('hentTestnokkelForOnboardingTrinn1', () => {
         expect(hentTekstnokkelForOnboardingTrinn1(plussDager(new Date(), -10).toISOString())).toBe('trinn1Fortid');
     });
 
+    it('returnerer "trinn1-Imorgen" når dato er 1 dag tilbake i tid', () => {
+        expect(hentTekstnokkelForOnboardingTrinn1(plussDager(new Date(), -1).toISOString())).toBe('trinn1Imorgen');
+    });
+
     it('returnerer "trinn1-idag" når dato er idag', () => {
         expect(hentTekstnokkelForOnboardingTrinn1(datoUtenTid(new Date().toISOString()).toISOString())).toBe(
             'trinn1Idag'

--- a/src/lib/hent-tekstnokkel-for-onboarding-trinn1.ts
+++ b/src/lib/hent-tekstnokkel-for-onboarding-trinn1.ts
@@ -1,18 +1,21 @@
 import dagerFraDato from '../utils/dager-fra-dato';
 
-type TekstNokkel = 'trinn1' | 'trinn1Fortid' | 'trinn1Idag' | 'trinn1Fremtid';
+type TekstNokkel = 'trinn1' | 'trinn1Fortid' | 'trinn1Idag' | 'trinn1Imorgen' | 'trinn1Fremtid';
 
-function hentTekstnokkelForOnboardingTrinn1(arbeidsledigDato?: Date): TekstNokkel {
+function hentTekstnokkelForOnboardingTrinn1(arbeidsledigDato?: string | null): TekstNokkel {
     if (!arbeidsledigDato) {
         return 'trinn1';
     }
 
-    const delta = dagerFraDato(new Date(), arbeidsledigDato);
+    const dato = new Date(arbeidsledigDato);
+    const delta = dagerFraDato(new Date(), dato);
 
     if (delta < 0) {
         return 'trinn1Fortid';
     } else if (delta === 0) {
         return 'trinn1Idag';
+    } else if (delta === 1) {
+        return 'trinn1Imorgen';
     } else {
         return 'trinn1Fremtid';
     }

--- a/src/lib/hent-tekstnokkel-for-onboarding-trinn1.ts
+++ b/src/lib/hent-tekstnokkel-for-onboarding-trinn1.ts
@@ -10,11 +10,11 @@ function hentTekstnokkelForOnboardingTrinn1(arbeidsledigDato?: string | null): T
     const dato = new Date(arbeidsledigDato);
     const delta = dagerFraDato(new Date(), dato);
 
-    if (delta < 0) {
+    if (delta < -1) {
         return 'trinn1Fortid';
     } else if (delta === 0) {
         return 'trinn1Idag';
-    } else if (delta === 1) {
+    } else if (delta === -1) {
         return 'trinn1Imorgen';
     } else {
         return 'trinn1Fremtid';

--- a/src/mocks/gjelder-fra-mock.ts
+++ b/src/mocks/gjelder-fra-mock.ts
@@ -1,5 +1,0 @@
-const gjelderFraGetResponse = {
-    dato: '2022-06-30',
-};
-
-export default gjelderFraGetResponse;

--- a/src/mocks/gjelder-fra-mock.ts
+++ b/src/mocks/gjelder-fra-mock.ts
@@ -1,5 +1,5 @@
 const gjelderFraGetResponse = {
-    dato: '2022-08-23',
+    dato: '2022-06-30',
 };
 
 export default gjelderFraGetResponse;

--- a/src/mocks/gjelder-fra-mock.ts
+++ b/src/mocks/gjelder-fra-mock.ts
@@ -1,5 +1,5 @@
 const gjelderFraGetResponse = {
-    dato: '2022-06-22',
+    dato: '2022-08-23',
 };
 
 export default gjelderFraGetResponse;

--- a/src/mocks/gjelder-fra-mock.ts
+++ b/src/mocks/gjelder-fra-mock.ts
@@ -1,5 +1,5 @@
 const gjelderFraGetResponse = {
-    dato: null,
+    dato: '2022-06-22',
 };
 
 export default gjelderFraGetResponse;

--- a/src/mocks/gjelderfra-mock.ts
+++ b/src/mocks/gjelderfra-mock.ts
@@ -1,0 +1,5 @@
+const gjelderFraGetResponse = {
+    dato: '2022-06-30',
+};
+
+export default gjelderFraGetResponse;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -3,7 +3,7 @@ import AuthResponse from './auth-mock';
 import ulesteDialogerResponse from './ulestedialoger-mock';
 import egenvurderingbesvarelseResponse from './egenvurderingbesvarelse-mock';
 // import brukerRegistreringResponse from './brukerregistrering-sykmeldt-mock';
-import gjelderFraResponse from './gjelder-fra-mock';
+import gjelderFraResponse from './gjelderfra-mock';
 import brukerRegistreringResponse from './brukerregistrering-standard-mock';
 import motestotteResponse from './motestotte-mock';
 import featureTogglesResponse from './feature-toggles-mock';


### PR DESCRIPTION
For å kunne gi mer presis veiledning om tidspunktet for å søke om dagpenger trenger vi informasjon om siste dag arbeidssøker mottar lønn.

Denne PR gjør slik funksjonalitet tilgjengelig for arbeidssøkere som er profilert til standard innsats, er inne i sin første uke som arbeidssøker og har valgt "MISTET_JOBBEN" som sin situasjon i registreringen.

Funksjonaliteten er lagt bak en featuretoggle `veientilarbeid.vis-arbeidsledig-dato`. Frem til tekstene for veiledning er godkjent skal toggle bare eksponeres i dev-miljøet. 

For arbeidssøkeren så er datovalget i en modal som åpnes enten ved at det sende med parameter etter arbeidssøkerregistreringen er gjennomført eller ved at arbeidssøkeren trykker på en link for å legge inn eller endre dato.