### PR TITLE
r Gjør så oppdatert dato vises i demoen for onboarding standard

### DIFF
--- a/src/demo/setup-demo-mock.ts
+++ b/src/demo/setup-demo-mock.ts
@@ -36,19 +36,14 @@ import {
     hentDpInnsynVedtak,
     hentDpInnsynSoknad,
     hentDpInnsynPaabegynte,
-    settGjelderFraDato,
 } from './demo-state';
 
 import { hentBrukerRegistrering } from './demo-state-brukerregistrering';
 import { AUTH_API } from '../komponenter/hent-initial-data/autentiseringsInfoFetcher';
 import msw_get from '../mocks/msw-utils';
 import meldekortstatusResponse from '../mocks/meldekortstatus-mock';
-import gjelderFraDatoMock from '../mocks/gjelderfra-mock';
-import { rest, RestRequest } from 'msw';
-
-interface GjelderFraBody {
-    dato: string;
-}
+import { rest } from 'msw';
+import { gjelderFraGetResolver, gjelderFraPostResolver } from '../mocks/gjelderfra-mock';
 
 export const demo_handlers = [
     msw_get(VEILARBOPPFOLGING_URL, {
@@ -95,11 +90,6 @@ export const demo_handlers = [
 
     msw_get(SAKSTEMA_URL, hentDpSakstema()),
 
-    msw_get(GJELDER_FRA_DATO_URL, gjelderFraDatoMock),
-    rest.post(GJELDER_FRA_DATO_URL, (req: RestRequest<GjelderFraBody>, res, ctx) => {
-        const { dato } = req.body;
-        settGjelderFraDato(dato);
-        window.location.reload();
-        return res(ctx.status(201));
-    }),
+    rest.get(GJELDER_FRA_DATO_URL, gjelderFraGetResolver),
+    rest.post(GJELDER_FRA_DATO_URL, gjelderFraPostResolver),
 ];

--- a/src/mocks/gjelderfra-mock.ts
+++ b/src/mocks/gjelderfra-mock.ts
@@ -1,16 +1,20 @@
-function hentGjelderFraDato() {
-    const fallbackDato = '2022-06-30';
-    try {
-        const gjelderFraDato = new URLSearchParams(window.location.search).get('gjelderFraDato');
-        return gjelderFraDato || fallbackDato;
-    } catch (error) {
-        console.error(error);
-        return fallbackDato;
-    }
+import { ResponseComposition, RestContext, RestRequest } from 'msw';
+import { hentGjelderFraDato, settGjelderFraDato } from '../demo/demo-state';
+
+interface DatoBody {
+    dato: string;
 }
 
-const gjelderFraGetResponse = {
-    dato: hentGjelderFraDato(),
+export const gjelderFraGetResolver = (req: RestRequest, res: ResponseComposition, ctx: RestContext) => {
+    return res(
+        ctx.json({
+            dato: hentGjelderFraDato(),
+        })
+    );
 };
 
-export default gjelderFraGetResponse;
+export const gjelderFraPostResolver = (req: RestRequest<DatoBody>, res: ResponseComposition, ctx: RestContext) => {
+    const { dato } = req.body;
+    settGjelderFraDato(dato);
+    return res(ctx.status(201));
+};

--- a/src/mocks/gjelderfra-mock.ts
+++ b/src/mocks/gjelderfra-mock.ts
@@ -18,3 +18,9 @@ export const gjelderFraPostResolver = (req: RestRequest<DatoBody>, res: Response
     settGjelderFraDato(dato);
     return res(ctx.status(201));
 };
+
+const gjelderFraGetResponse = {
+    dato: null,
+};
+
+export default gjelderFraGetResponse;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -2,8 +2,6 @@ import { AUTH_API } from '../komponenter/hent-initial-data/autentiseringsInfoFet
 import AuthResponse from './auth-mock';
 import ulesteDialogerResponse from './ulestedialoger-mock';
 import egenvurderingbesvarelseResponse from './egenvurderingbesvarelse-mock';
-// import brukerRegistreringResponse from './brukerregistrering-sykmeldt-mock';
-import gjelderFraResponse from './gjelderfra-mock';
 import brukerRegistreringResponse from './brukerregistrering-standard-mock';
 import motestotteResponse from './motestotte-mock';
 import featureTogglesResponse from './feature-toggles-mock';
@@ -17,7 +15,7 @@ import dpVedtakResponse from './dp-innsyn-vedtak';
 import dpPaabegynteResponse from './dp-innsyn-paabegynte';
 import paabegynteSoknaderResponse from './saksoversikt-pabegyntesoknader-mock';
 import sakstemaResponse from './saksoversikt-sakstema-mock';
-import msw_get, { msw_post } from './msw-utils';
+import msw_get from './msw-utils';
 import {
     BRUKERINFO_URL,
     BRUKERREGISTRERING_URL,
@@ -34,6 +32,8 @@ import {
     DP_INNSYN_URL,
     GJELDER_FRA_DATO_URL,
 } from '../ducks/api';
+import { gjelderFraGetResolver, gjelderFraPostResolver } from './gjelderfra-mock';
+import { rest } from 'msw';
 
 export const handlers = [
     msw_get(AUTH_API, AuthResponse),
@@ -52,6 +52,6 @@ export const handlers = [
     msw_get(`${DP_INNSYN_URL}/soknad`, dpSoknadResonse),
     msw_get(`${DP_INNSYN_URL}/vedtak`, dpVedtakResponse),
     msw_get(`${DP_INNSYN_URL}/paabegynte`, dpPaabegynteResponse),
-    msw_get(GJELDER_FRA_DATO_URL, gjelderFraResponse),
-    msw_post(GJELDER_FRA_DATO_URL, null, 204),
+    rest.get(GJELDER_FRA_DATO_URL, gjelderFraGetResolver),
+    rest.post(GJELDER_FRA_DATO_URL, gjelderFraPostResolver),
 ];


### PR DESCRIPTION
Lager denne PR-en så ingen morgenfugler begynner på samme oppgave i morgen tidlig 🐥
 
Se gjerne over om noe burde endres eller flyttes på. Hører resolverne mer hjemme i demomappa enn i mock-fila? Og hva bør egentlig returneres når vi skal bruke mock, men ikke er i demoversjonen? Jeg har bare gjort det likt for nå 🤷  

Har testet lokalt at datoene oppdateres riktig i demoversjonen.