### PR TITLE
Bruker arbeidssøkerperioder når vi ser på dagpengerstatus i stedet for registreringsdata

### DIFF
--- a/src/komponenter/dagpenger/dagpenger-og-ytelser-innhold.tsx
+++ b/src/komponenter/dagpenger/dagpenger-og-ytelser-innhold.tsx
@@ -7,6 +7,7 @@ import { useBrukerregistreringData } from '../../contexts/brukerregistrering';
 import { useDpInnsynSoknadData } from '../../contexts/dp-innsyn-soknad';
 import { useDpInnsynVedtakData } from '../../contexts/dp-innsyn-vedtak';
 import { useDpInnsynPaabegynteSoknaderData } from '../../contexts/dp-innsyn-paabegynte-soknader';
+import { useArbeidssokerperioderData } from '../../contexts/arbeidssokerperioder';
 
 import HarIkkeSokt from './dagpenger-har-ikke-sokt';
 import HarPabegyntSoknad from './dagpenger-har-paabegynt-soknad';
@@ -19,6 +20,7 @@ import ErRendret from '../er-rendret/er-rendret';
 import InViewport from '../in-viewport/in-viewport';
 import ByttKortLenke from './bytt-kort-lenke';
 import Ytelser from './ytelser';
+import beregnArbeidssokerperioder from '../../lib/beregn-arbeidssokerperioder';
 
 function hentDagpengerInnhold(situasjon: DagpengeStatus) {
     if (situasjon === 'paabegynt') {
@@ -47,6 +49,8 @@ function DagpengerOgYtelserInnhold(props: Props) {
     const paabegynteSoknader = useDpInnsynPaabegynteSoknaderData();
     const innsendteSoknader = useDpInnsynSoknadData();
     const dagpengeVedtak = useDpInnsynVedtakData();
+    const arbeidssokerperioderData = useArbeidssokerperioderData();
+    const arbeidssokerperioder = beregnArbeidssokerperioder(arbeidssokerperioderData);
 
     const dagpengeStatus = beregnDagpengeStatus({
         brukerInfoData,
@@ -54,6 +58,7 @@ function DagpengerOgYtelserInnhold(props: Props) {
         paabegynteSoknader,
         innsendteSoknader,
         dagpengeVedtak,
+        arbeidssokerperioder,
     });
 
     const DagpengerInnhold = hentDagpengerInnhold(dagpengeStatus);

--- a/src/komponenter/hent-initial-data/amplitude-provider.tsx
+++ b/src/komponenter/hent-initial-data/amplitude-provider.tsx
@@ -172,13 +172,23 @@ export const AmplitudeProvider = (props: { children: React.ReactNode }) => {
         oppfolgingData,
     });
 
+    const beregnedeArbeidssokerPerioder = beregnArbeidssokerperioder(arbeidssokerperioder);
+
     const dagpengestatus = beregnDagpengeStatus({
         brukerInfoData,
         registreringData: brukerregistreringData,
         paabegynteSoknader: pabegynteSoknaderData,
         innsendteSoknader,
         dagpengeVedtak,
+        arbeidssokerperioder: beregnedeArbeidssokerPerioder,
     });
+
+    const {
+        harAktivArbeidssokerperiode,
+        antallDagerSidenSisteArbeidssokerperiode,
+        antallUkerSidenSisteArbeidssokerperiode,
+        antallUkerMellomSisteArbeidssokerperioder,
+    } = beregnedeArbeidssokerPerioder;
 
     const sisteDagpengevedtak = dagpengeVedtak
         .filter((vedtak) => vedtak.status === 'INNVILGET')
@@ -200,13 +210,6 @@ export const AmplitudeProvider = (props: { children: React.ReactNode }) => {
 
     const valgtSprak = hentSprakValgFraCookie();
     const sprakValgFraCookie = valgtSprak || 'IKKE_VALGT';
-
-    const {
-        harAktivArbeidssokerperiode,
-        antallDagerSidenSisteArbeidssokerperiode,
-        antallUkerSidenSisteArbeidssokerperiode,
-        antallUkerMellomSisteArbeidssokerperioder,
-    } = beregnArbeidssokerperioder(arbeidssokerperioder);
 
     const amplitudeData: AmplitudeData = {
         gruppe: POAGruppe,

--- a/src/komponenter/meldekort/meldekort-advarsel.tsx
+++ b/src/komponenter/meldekort/meldekort-advarsel.tsx
@@ -1,16 +1,19 @@
 import { Heading, BodyShort, BodyLong } from '@navikt/ds-react';
 
 import { useBrukerinfoData } from '../../contexts/bruker-info';
-import { beregnDagerTilInaktivering } from '../../utils/meldekort-utils';
-import { datoMedUkedag, plussDager } from '../../utils/date-utils';
-import { hentIDag } from '../../utils/chrono';
 import { useBrukerregistreringData } from '../../contexts/brukerregistrering';
-import beregnDagpengeStatus, { DagpengeStatus } from '../../lib/beregn-dagpenge-status';
 import { useDpInnsynSoknadData } from '../../contexts/dp-innsyn-soknad';
 import { useDpInnsynVedtakData } from '../../contexts/dp-innsyn-vedtak';
 import { useDpInnsynPaabegynteSoknaderData } from '../../contexts/dp-innsyn-paabegynte-soknader';
-import lagHentTekstForSprak from '../../lib/lag-hent-tekst-for-sprak';
 import { useSprakValg } from '../../contexts/sprak';
+import { useArbeidssokerperioderData } from '../../contexts/arbeidssokerperioder';
+
+import { beregnDagerTilInaktivering } from '../../utils/meldekort-utils';
+import { datoMedUkedag, plussDager } from '../../utils/date-utils';
+import { hentIDag } from '../../utils/chrono';
+import beregnDagpengeStatus, { DagpengeStatus } from '../../lib/beregn-dagpenge-status';
+import beregnArbeidssokerperioder from '../../lib/beregn-arbeidssokerperioder';
+import lagHentTekstForSprak from '../../lib/lag-hent-tekst-for-sprak';
 // TODO - oversette alle tekster til engelsk
 const TEKSTER = {
     nb: {
@@ -79,6 +82,8 @@ function MeldekortAdvarsel({ dagerEtterFastsattMeldedag }: { dagerEtterFastsattM
     const paabegynteSoknader = useDpInnsynPaabegynteSoknaderData();
     const innsendteSoknader = useDpInnsynSoknadData();
     const dagpengeVedtak = useDpInnsynVedtakData();
+    const arbeidssokerperioderData = useArbeidssokerperioderData();
+    const arbeidssokerperioder = beregnArbeidssokerperioder(arbeidssokerperioderData);
 
     const dagpengeStatus = beregnDagpengeStatus({
         brukerInfoData,
@@ -86,6 +91,7 @@ function MeldekortAdvarsel({ dagerEtterFastsattMeldedag }: { dagerEtterFastsattM
         paabegynteSoknader,
         innsendteSoknader,
         dagpengeVedtak,
+        arbeidssokerperioder,
     });
 
     const sprak = useSprakValg().sprak;

--- a/src/komponenter/onboarding-ytelser/dagpenger/sluttkort.tsx
+++ b/src/komponenter/onboarding-ytelser/dagpenger/sluttkort.tsx
@@ -1,17 +1,20 @@
+import { useBrukerinfoData } from '../../../contexts/bruker-info';
+import { useBrukerregistreringData } from '../../../contexts/brukerregistrering';
+import { useDpInnsynSoknadData } from '../../../contexts/dp-innsyn-soknad';
+import { useDpInnsynVedtakData } from '../../../contexts/dp-innsyn-vedtak';
+import { useDpInnsynPaabegynteSoknaderData } from '../../../contexts/dp-innsyn-paabegynte-soknader';
+import { useArbeidssokerperioderData } from '../../../contexts/arbeidssokerperioder';
+
 import HarIkkeSokt from './sluttkort-har-ikke-sokt';
 import HarPabegyntSoknad from './sluttkort-har-paabegynt-soknad';
 import HarSokt from './sluttkort-har-sokt';
 import MottarDagpenger from './sluttkort-faar-dagpenger';
 import InnvilgetDagpenger from './sluttkort-innvilget-dagpenger';
 import AvslagDagpenger from './sluttkort-avslag-dagpenger';
-import { useBrukerinfoData } from '../../../contexts/bruker-info';
-import { useBrukerregistreringData } from '../../../contexts/brukerregistrering';
-import { useDpInnsynSoknadData } from '../../../contexts/dp-innsyn-soknad';
-import { useDpInnsynVedtakData } from '../../../contexts/dp-innsyn-vedtak';
-import { useDpInnsynPaabegynteSoknaderData } from '../../../contexts/dp-innsyn-paabegynte-soknader';
 import beregnDagpengeStatus, { DagpengeStatus } from '../../../lib/beregn-dagpenge-status';
 import ErRendret from '../../er-rendret/er-rendret';
 import InViewport from '../../in-viewport/in-viewport';
+import beregnArbeidssokerperioder from '../../../lib/beregn-arbeidssokerperioder';
 
 function hentAktueltSluttkort(situasjon: DagpengeStatus) {
     if (situasjon === 'paabegynt') {
@@ -35,6 +38,8 @@ function Sluttkort() {
     const paabegynteSoknader = useDpInnsynPaabegynteSoknaderData();
     const innsendteSoknader = useDpInnsynSoknadData();
     const dagpengeVedtak = useDpInnsynVedtakData();
+    const arbeidssokerperioderData = useArbeidssokerperioderData();
+    const arbeidssokerperioder = beregnArbeidssokerperioder(arbeidssokerperioderData);
 
     const dagpengeStatus = beregnDagpengeStatus({
         brukerInfoData,
@@ -42,6 +47,7 @@ function Sluttkort() {
         paabegynteSoknader,
         innsendteSoknader,
         dagpengeVedtak,
+        arbeidssokerperioder,
     });
 
     const AktueltSluttkort = hentAktueltSluttkort(dagpengeStatus);

--- a/src/komponenter/onboarding-ytelser/ytelser-onboarding.tsx
+++ b/src/komponenter/onboarding-ytelser/ytelser-onboarding.tsx
@@ -3,23 +3,26 @@ import { useState } from 'react';
 import { useBrukerinfoData } from '../../contexts/bruker-info';
 import { useFeatureToggleData } from '../../contexts/feature-toggles';
 import { useAmplitudeData } from '../../contexts/amplitude-context';
+import { useBrukerregistreringData } from '../../contexts/brukerregistrering';
+import { useOppfolgingData } from '../../contexts/oppfolging';
+import { useSprakValg } from '../../contexts/sprak';
+import { useDpInnsynPaabegynteSoknaderData } from '../../contexts/dp-innsyn-paabegynte-soknader';
+import { useDpInnsynSoknadData } from '../../contexts/dp-innsyn-soknad';
+import { useDpInnsynVedtakData } from '../../contexts/dp-innsyn-vedtak';
+import { useArbeidssokerperioderData } from '../../contexts/arbeidssokerperioder';
+
 import { kanViseOnboardingYtelser } from '../../lib/kan-vise-ytelser';
 import SluttkortYtelser from './ytelser/sluttkort';
 import SluttkortDagpenger from './dagpenger/sluttkort';
 import Tema from '../tema/tema';
-import { useBrukerregistreringData } from '../../contexts/brukerregistrering';
-import { useOppfolgingData } from '../../contexts/oppfolging';
 import { kanViseOnboardingDagpenger } from '../../lib/kan-vise-onboarding-dagpenger';
 import { amplitudeLogger } from '../../metrics/amplitude-utils';
 import { hentFraBrowserStorage, settIBrowserStorage } from '../../utils/browserStorage-utils';
 import lagHentTekstForSprak, { Tekster } from '../../lib/lag-hent-tekst-for-sprak';
-import { useSprakValg } from '../../contexts/sprak';
 import beregnDagpengeStatus from '../../lib/beregn-dagpenge-status';
 import harIkkeStartetDagpengesoknad from '../../lib/har-ikke-startet-dagpengesoknad';
-import { useDpInnsynPaabegynteSoknaderData } from '../../contexts/dp-innsyn-paabegynte-soknader';
-import { useDpInnsynSoknadData } from '../../contexts/dp-innsyn-soknad';
-import { useDpInnsynVedtakData } from '../../contexts/dp-innsyn-vedtak';
 import FotnoterYtelser from './fotnoter-ytelser';
+import beregnArbeidssokerperioder from '../../lib/beregn-arbeidssokerperioder';
 
 const TEKSTER: Tekster<string> = {
     nb: {
@@ -42,6 +45,8 @@ function YtelserOnboarding() {
     const dagpengeVedtak = useDpInnsynVedtakData();
     const amplitudeData = useAmplitudeData();
     const YTELSER_TEMA_VIS_KEY = 'ytelser_tema_vis_key';
+    const arbeidssokerperioderData = useArbeidssokerperioderData();
+    const arbeidssokerperioder = beregnArbeidssokerperioder(arbeidssokerperioderData);
 
     const kanViseDagpengerKomponent = kanViseOnboardingDagpenger({
         featuretoggleData,
@@ -83,6 +88,7 @@ function YtelserOnboarding() {
         paabegynteSoknader,
         innsendteSoknader,
         dagpengeVedtak,
+        arbeidssokerperioder,
     });
 
     if (!kanViseYtelserKomponent && !kanViseDagpengerKomponent) return null;

--- a/src/komponenter/onboardingMeldekort/meldekort-advarsel.tsx
+++ b/src/komponenter/onboardingMeldekort/meldekort-advarsel.tsx
@@ -1,16 +1,19 @@
 import { Heading, BodyShort, BodyLong } from '@navikt/ds-react';
 
 import { useBrukerinfoData } from '../../contexts/bruker-info';
-import { beregnDagerTilInaktivering } from '../../utils/meldekort-utils';
-import { datoMedUkedag, plussDager } from '../../utils/date-utils';
-import { hentIDag } from '../../utils/chrono';
 import { useBrukerregistreringData } from '../../contexts/brukerregistrering';
-import beregnDagpengeStatus, { DagpengeStatus } from '../../lib/beregn-dagpenge-status';
 import { useDpInnsynSoknadData } from '../../contexts/dp-innsyn-soknad';
 import { useDpInnsynVedtakData } from '../../contexts/dp-innsyn-vedtak';
 import { useDpInnsynPaabegynteSoknaderData } from '../../contexts/dp-innsyn-paabegynte-soknader';
-import lagHentTekstForSprak from '../../lib/lag-hent-tekst-for-sprak';
 import { useSprakValg } from '../../contexts/sprak';
+import { useArbeidssokerperioderData } from '../../contexts/arbeidssokerperioder';
+
+import { beregnDagerTilInaktivering } from '../../utils/meldekort-utils';
+import { datoMedUkedag, plussDager } from '../../utils/date-utils';
+import { hentIDag } from '../../utils/chrono';
+import beregnDagpengeStatus, { DagpengeStatus } from '../../lib/beregn-dagpenge-status';
+import lagHentTekstForSprak from '../../lib/lag-hent-tekst-for-sprak';
+import beregnArbeidssokerperioder from '../../lib/beregn-arbeidssokerperioder';
 // TODO - oversette alle tekster til engelsk
 const TEKSTER = {
     nb: {
@@ -79,6 +82,8 @@ function MeldekortAdvarsel({ dagerEtterFastsattMeldedag }: { dagerEtterFastsattM
     const paabegynteSoknader = useDpInnsynPaabegynteSoknaderData();
     const innsendteSoknader = useDpInnsynSoknadData();
     const dagpengeVedtak = useDpInnsynVedtakData();
+    const arbeidssokerperioderData = useArbeidssokerperioderData();
+    const arbeidssokerperioder = beregnArbeidssokerperioder(arbeidssokerperioderData);
 
     const dagpengeStatus = beregnDagpengeStatus({
         brukerInfoData,
@@ -86,6 +91,7 @@ function MeldekortAdvarsel({ dagerEtterFastsattMeldedag }: { dagerEtterFastsattM
         paabegynteSoknader,
         innsendteSoknader,
         dagpengeVedtak,
+        arbeidssokerperioder,
     });
 
     const sprak = useSprakValg().sprak;

--- a/src/lib/beregn-arbeidssokerperioder.test.ts
+++ b/src/lib/beregn-arbeidssokerperioder.test.ts
@@ -7,6 +7,7 @@ describe('tester funksjonen beregnArbeidssokerperioder', () => {
 
         const forventetVerdi = {
             harAktivArbeidssokerperiode: 'INGEN_DATA',
+            aktivPeriodeStart: 'INGEN_DATA',
             antallDagerSidenSisteArbeidssokerperiode: 'INGEN_DATA',
             antallUkerSidenSisteArbeidssokerperiode: 'INGEN_DATA',
             antallUkerMellomSisteArbeidssokerperioder: 'INGEN_DATA',
@@ -22,6 +23,7 @@ describe('tester funksjonen beregnArbeidssokerperioder', () => {
         };
         const forventetVerdi = {
             harAktivArbeidssokerperiode: 'N/A',
+            aktivPeriodeStart: 'N/A',
             antallDagerSidenSisteArbeidssokerperiode: 'N/A',
             antallUkerSidenSisteArbeidssokerperiode: 'N/A',
             antallUkerMellomSisteArbeidssokerperioder: 'N/A',
@@ -44,6 +46,36 @@ describe('tester funksjonen beregnArbeidssokerperioder', () => {
         const verdi = beregnArbeidssokerperioder(data);
 
         expect(verdi.harAktivArbeidssokerperiode).toEqual(forventetVerdi);
+    });
+
+    test('Vi får aktivPeriodeStart lik fraOgMedDato perioden ikke er avsluttet', () => {
+        const data = {
+            arbeidssokerperioder: [
+                {
+                    fraOgMedDato: '2020-01-01',
+                    tilOgMedDato: null,
+                },
+            ],
+        };
+        const forventetVerdi = '2020-01-01';
+        const verdi = beregnArbeidssokerperioder(data);
+
+        expect(verdi.aktivPeriodeStart).toEqual(forventetVerdi);
+    });
+
+    test('Vi får "Ingen aktive perioder" på aktivPeriodeStart dersom siste periode er avsluttet', () => {
+        const data = {
+            arbeidssokerperioder: [
+                {
+                    fraOgMedDato: '2020-01-01',
+                    tilOgMedDato: '2020-05-05',
+                },
+            ],
+        };
+        const forventetVerdi = 'Ingen aktive perioder';
+        const verdi = beregnArbeidssokerperioder(data);
+
+        expect(verdi.aktivPeriodeStart).toEqual(forventetVerdi);
     });
 
     test('Vi får Nei på aktiv arbeidssøkerperiode om perioden ikke er avsluttet', () => {

--- a/src/lib/beregn-arbeidssokerperioder.ts
+++ b/src/lib/beregn-arbeidssokerperioder.ts
@@ -5,6 +5,7 @@ import dagerFraDato from '../utils/dager-fra-dato';
 
 export interface BeregnedePerioder {
     harAktivArbeidssokerperiode: 'INGEN_DATA' | 'N/A' | 'Ja' | 'Nei';
+    aktivPeriodeStart: 'INGEN_DATA' | 'N/A' | string | 'Ingen aktive perioder';
     antallDagerSidenSisteArbeidssokerperiode: number | 'Ikke avsluttet' | 'INGEN_DATA' | 'N/A';
     antallUkerSidenSisteArbeidssokerperiode: number | 'Ikke avsluttet' | 'INGEN_DATA' | 'N/A';
     antallUkerMellomSisteArbeidssokerperioder: number | 'INGEN_DATA' | 'N/A' | 'Første periode';
@@ -43,6 +44,7 @@ function beregnArbeidssokerperioder(props: Props | null): BeregnedePerioder {
     if (arbeidssokerperioder === null) {
         return {
             harAktivArbeidssokerperiode: 'INGEN_DATA',
+            aktivPeriodeStart: 'INGEN_DATA',
             antallDagerSidenSisteArbeidssokerperiode: 'INGEN_DATA',
             antallUkerSidenSisteArbeidssokerperiode: 'INGEN_DATA',
             antallUkerMellomSisteArbeidssokerperioder: 'INGEN_DATA',
@@ -52,6 +54,7 @@ function beregnArbeidssokerperioder(props: Props | null): BeregnedePerioder {
     if (arbeidssokerperioder.length === 0) {
         return {
             harAktivArbeidssokerperiode: 'N/A',
+            aktivPeriodeStart: 'N/A',
             antallDagerSidenSisteArbeidssokerperiode: 'N/A',
             antallUkerSidenSisteArbeidssokerperiode: 'N/A',
             antallUkerMellomSisteArbeidssokerperioder: 'N/A',
@@ -66,6 +69,9 @@ function beregnArbeidssokerperioder(props: Props | null): BeregnedePerioder {
 
     return {
         harAktivArbeidssokerperiode: aktivArbeidssokerperiode ? 'Ja' : 'Nei',
+        aktivPeriodeStart: aktivArbeidssokerperiode
+            ? new Date(arbeidssokerperioder[0].fraOgMedDato).toISOString().substring(0, 10)
+            : 'Ingen aktive perioder',
         antallDagerSidenSisteArbeidssokerperiode: aktivArbeidssokerperiode
             ? 'Ikke avsluttet'
             : beregnAntallDagerSidenSisteArbeidssokerperiode(sluttDatoSistePeriode),

--- a/src/lib/beregn-dagpenge-status.test.ts
+++ b/src/lib/beregn-dagpenge-status.test.ts
@@ -11,6 +11,13 @@ const grunndata = {
         alder: 42,
         erSykmeldtMedArbeidsgiver: false,
     },
+    arbeidssokerperioder: {
+        harAktivArbeidssokerperiode: 'INGEN_DATA',
+        aktivPeriodeStart: 'INGEN_DATA',
+        antallDagerSidenSisteArbeidssokerperiode: 'INGEN_DATA',
+        antallUkerSidenSisteArbeidssokerperiode: 'INGEN_DATA',
+        antallUkerMellomSisteArbeidssokerperioder: 'INGEN_DATA',
+    },
     registreringData: {
         registrering: {
             opprettetDato: iDag.toISOString(),
@@ -30,6 +37,7 @@ const grunndata = {
         },
     },
 };
+
 describe('Tester funksjonen beregnDagpengeStatus', () => {
     test('returnerer "mottar" når bruker mottar dagpenger', () => {
         const testData = JSON.parse(JSON.stringify(grunndata));

--- a/src/lib/beregn-dagpenge-status.test.ts
+++ b/src/lib/beregn-dagpenge-status.test.ts
@@ -53,7 +53,7 @@ describe('Tester funksjonen beregnDagpengeStatus', () => {
         ).toBe('mottar');
     });
 
-    test('returnerer "ukjent" hvis ingen registreringsdato', () => {
+    test('returnerer "ukjent" hvis ingen registreringsdato og ingen arbeidssøkerperioder', () => {
         const testData = JSON.parse(JSON.stringify(grunndata));
         delete testData.registreringData.registrering.opprettetDato;
 
@@ -179,6 +179,35 @@ describe('Tester funksjonen beregnDagpengeStatus', () => {
 
     test('returnerer "paabegynt" når det eksisterer påbegynte søknader', () => {
         const testData = JSON.parse(JSON.stringify(grunndata));
+        const soknader = [
+            {
+                tittel: 'Søknad om dagpenger (ikke permittert)',
+                behandlingsId: '10010WQX9',
+                sistEndret: plussDager(iDag, 1).toISOString(),
+            },
+        ];
+
+        return expect(
+            beregnDagpengeStatus({
+                ...testData,
+                paabegynteSoknader: soknader,
+                innsendteSoknader: [],
+                dagpengeVedtak: [],
+            })
+        ).toBe('paabegynt');
+    });
+
+    test('returnerer "paabegynt" når det eksisterer påbegynte søknader også for de som er registrert før ny løsning', () => {
+        const testData = JSON.parse(JSON.stringify(grunndata));
+        delete testData.registreringData.registrering.opprettetDato;
+        testData.arbeidssokerperioder = {
+            harAktivArbeidssokerperiode: 'Ja',
+            aktivPeriodeStart: '2018-06-26',
+            antallDagerSidenSisteArbeidssokerperiode: 'INGEN_DATA',
+            antallUkerSidenSisteArbeidssokerperiode: 'INGEN_DATA',
+            antallUkerMellomSisteArbeidssokerperioder: 'INGEN_DATA',
+        };
+
         const soknader = [
             {
                 tittel: 'Søknad om dagpenger (ikke permittert)',

--- a/src/lib/beregn-dagpenge-status.ts
+++ b/src/lib/beregn-dagpenge-status.ts
@@ -11,6 +11,7 @@ import * as BrukerInfo from '../contexts/bruker-info';
 import { DpInnsynSoknad } from '../contexts/dp-innsyn-soknad';
 import { DpInnsynPaabegyntSoknad } from '../contexts/dp-innsyn-paabegynte-soknader';
 import { Vedtak } from '../contexts/dp-innsyn-vedtak';
+import { BeregnedePerioder } from './beregn-arbeidssokerperioder';
 
 // import { plussDager } from '../utils/date-utils';
 
@@ -37,24 +38,31 @@ function beregnDagpengeStatus({
     paabegynteSoknader,
     innsendteSoknader,
     dagpengeVedtak,
+    arbeidssokerperioder,
 }: {
     brukerInfoData: BrukerInfo.Data;
     registreringData: Brukerregistrering.Data | null;
     paabegynteSoknader: DpInnsynPaabegyntSoknad[];
     innsendteSoknader: DpInnsynSoknad[];
     dagpengeVedtak: Vedtak[];
+    arbeidssokerperioder: BeregnedePerioder;
 }): DagpengeStatus {
     const { rettighetsgruppe } = brukerInfoData;
+    const { aktivPeriodeStart, harAktivArbeidssokerperiode } = arbeidssokerperioder;
+    const erIaktivPeriode = harAktivArbeidssokerperiode === 'Ja';
+    const harOpprettetDato = registreringData?.registrering?.opprettetDato;
 
     if (rettighetsgruppe === 'DAGP') {
         return 'mottar';
     }
 
-    if (!registreringData?.registrering?.opprettetDato) {
+    if (!harOpprettetDato && !erIaktivPeriode) {
         return 'ukjent';
     }
 
-    const registreringsDato = new Date(registreringData?.registrering!.opprettetDato);
+    const registreringsDato = harOpprettetDato
+        ? new Date(registreringData?.registrering!.opprettetDato)
+        : new Date(aktivPeriodeStart);
     const sistInnsendteSoknad = innsendteSoknader.sort(sorterEtterNyesteDatoInnsendt)[0];
     const sisteDagpengevedtak = dagpengeVedtak.sort(sorterEtterNyesteVedtak)[0];
 

--- a/src/test/test-context-providers.tsx
+++ b/src/test/test-context-providers.tsx
@@ -1,6 +1,9 @@
+import * as React from 'react';
 import merge from 'merge-deep';
+
 import * as Amplitude from '../contexts/amplitude-context';
 import { AmplitudeData } from '../metrics/amplitude-utils';
+import * as Arbeidssokerperioder from '../contexts/arbeidssokerperioder';
 import * as Autentisering from '../contexts/autentisering';
 import * as Brukerregistrering from '../contexts/brukerregistrering';
 import * as FeatureToggle from '../contexts/feature-toggles';
@@ -12,7 +15,6 @@ import * as Meldekort from '../contexts/meldekort';
 import * as Motestotte from '../contexts/motestotte';
 import * as UnderOppfolging from '../contexts/under-oppfolging';
 import * as Sakstema from '../contexts/sakstema';
-import * as React from 'react';
 import { STATUS } from '../ducks/api';
 import { setFastTidspunktForIDag } from '../utils/chrono';
 import { GlobaleInnstillingerProps, GlobaleInnstillingerProvider } from '../contexts/GlobaleInnstillinger';
@@ -25,6 +27,7 @@ type DeepPartial<T> = {
 export type ProviderProps = {
     autentisering?: DeepPartial<Autentisering.Data>;
     amplitude?: DeepPartial<AmplitudeData>;
+    arbeidssokerperioder?: DeepPartial<Arbeidssokerperioder.Data>;
     brukerregistrering?: DeepPartial<Brukerregistrering.Data> | null;
     featureToggle?: DeepPartial<FeatureToggle.Data>;
     egenvurdering?: DeepPartial<Egenvurdering.Data>;
@@ -114,7 +117,16 @@ export const contextProviders = function (props: ProviderProps): React.FunctionC
                                                                     }
                                                                 )}
                                                             >
-                                                                <KanViseVTA>{children}</KanViseVTA>
+                                                                <Arbeidssokerperioder.ArbeidssokerperioderContext.Provider
+                                                                    value={merge(
+                                                                        Arbeidssokerperioder.initialState,
+                                                                        props.arbeidssokerperioder && {
+                                                                            data: props.arbeidssokerperioder,
+                                                                        }
+                                                                    )}
+                                                                >
+                                                                    <KanViseVTA>{children}</KanViseVTA>
+                                                                </Arbeidssokerperioder.ArbeidssokerperioderContext.Provider>
                                                             </FeatureToggle.FeaturetoggleContext.Provider>
                                                         </Sakstema.SakstemaContext.Provider>
                                                     </Amplitude.AmplitudeContext.Provider>


### PR DESCRIPTION
Siden registreringsdata kun finnes på de som er registrert etter at ny løsing kom på luften (høst 2018) får vi noen tilfeller hvor beregningen av søknadsstatus for dagpenger ikke oppdateres siden den bryter beregning om registreringsdata ikke finnes.

En mulig løsning på problemet vil være å benytte arbeidssøkerperioder i stedet siden de vil gå mye lenger tilbake i tid.

Denne PR innfører `aktivPeriodeStart` på arbeidssøkerperiodeberegningen og så vil beregn-dagpengestatus basere seg på den i stedet i de tilfellene hvor registreringsdata ikke finnes. 