### PR TITLE
Refaktorer logikk for om man skal se egenvurdering i ny komponent

### DIFF
--- a/src/komponenter/hjelp-og-stotte/hjelp-og-stotte.tsx
+++ b/src/komponenter/hjelp-og-stotte/hjelp-og-stotte.tsx
@@ -83,38 +83,40 @@ function HjelpOgStotte() {
 
     const sistSettEgenvurdering = Number(hentFraBrowserStorage(INTRO_KEY_12UKER)) ?? 0;
 
-    const skalViseEgenvurderingsUke12 = kanVise12UkerEgenvurdering({
-        brukerInfoData,
-        egenvurderingData,
-        oppfolgingData,
-        registreringData,
-        amplitudeData,
-        featuretoggleData,
-        sistVistFraLocalstorage: sistSettEgenvurdering,
-    });
-
-    const skalViseEgenvurderingNyregistrert = kanViseIVURDEgenvurdering({
-        underOppfolgingData,
-        registreringData,
-        autentiseringData,
-        egenvurderingData,
-        oppfolgingData,
-    });
     const harAvslattEgenvurdering = hentFraBrowserStorage(AVSLAATT_EGENVURDERING);
 
-    const skalViseEgenvurderingIVURD =
-        featuretoggleEgenvurderingAktivert && skalViseEgenvurderingNyregistrert && !harAvslattEgenvurdering;
+    const skalViseEgenvurderingInnsatsgruppeIkkeFastsatt =
+        featuretoggleEgenvurderingAktivert &&
+        !harAvslattEgenvurdering &&
+        kanViseIVURDEgenvurdering({
+            underOppfolgingData,
+            registreringData,
+            autentiseringData,
+            egenvurderingData,
+            oppfolgingData,
+        });
 
-    const skalViseEgenvurdering = skalViseEgenvurderingIVURD || (skalViseEgenvurderingsUke12 && skalViseKssInnhold);
+    const skalViseEgenvurderingUke12 =
+        skalViseKssInnhold &&
+        kanVise12UkerEgenvurdering({
+            brukerInfoData,
+            egenvurderingData,
+            oppfolgingData,
+            registreringData,
+            amplitudeData,
+            featuretoggleData,
+            sistVistFraLocalstorage: sistSettEgenvurdering,
+        });
 
-    const EgenVurderingMedLesLink = () => {
-        if (skalViseEgenvurderingIVURD) {
+    const skalViseEgenvurdering = skalViseEgenvurderingInnsatsgruppeIkkeFastsatt || skalViseEgenvurderingUke12;
+
+    const Egenvurdering = () => {
+        if (skalViseEgenvurderingInnsatsgruppeIkkeFastsatt) {
             return <EgenvurderingKort />;
         }
-        if (skalViseEgenvurderingsUke12) {
+        if (skalViseEgenvurderingUke12) {
             return <EgenvurderingUke12 />;
         }
-
         return null;
     };
 
@@ -147,7 +149,7 @@ function HjelpOgStotte() {
                 <Detail uppercase style={{ marginTop: '-1rem' }}>
                     Hjelp og støtte
                 </Detail>
-                {skalViseEgenvurdering ? <EgenVurderingMedLesLink /> : <DefaultInnhold />}
+                {skalViseEgenvurdering ? <Egenvurdering /> : <DefaultInnhold />}
                 <ReadMore size="medium" header={tekst('readMoreHeading')} onClick={handleClickLesMer}>
                     <Forklaring />
                 </ReadMore>


### PR DESCRIPTION
Det var flere variabler/funksjoner med lignende navn + at IVURD kan være et ukjent begrep for noen.

Dette er gjort: 

- Renamet EgenVurderingMedLesLink til Egenvurdering

- Samlet skalViseEgenvurderingNyregistrert og skalViseEgenvurderingIVURD i én const, siden begge handler om å sjekke om vi skal vise IVURD-egenvurderingen. Denne har nå det fryktelig lange navnet skalViseEgenvurderingInnsatsgruppeIkkeFastsatt

- Samlet skalViseEgenvurderingUke12 og skalViseKssInnhold i én const, siden begge brukes for å sjekke om vi skal vise egenvurdering uke 12