### PR TITLE
Alltid vis aktivitetsplan osv. hvis man er under oppfølging

### DIFF
--- a/src/innhold/ikke-arbeidssoker-innhold.tsx
+++ b/src/innhold/ikke-arbeidssoker-innhold.tsx
@@ -10,17 +10,18 @@ function IkkeArbeidssokerInnhold() {
     const underOppfolging = useUnderOppfolging()?.underoppfolging;
     const arbeidssokerperioder = beregnArbeidssokerperioder(arbeidssokerperioderData);
 
-    if (arbeidssokerperioder.antallDagerSidenSisteArbeidssokerperiode < 28) {
-        return <ReaktiveringWrapper />;
-    } else if (underOppfolging) {
-        return (
-            <ArbeidssokerDataProvider>
-                <InnholdUnderOppfolgingUtenPeriode />
-            </ArbeidssokerDataProvider>
-        );
-    }
-
-    return <IkkeRegistrert />;
+    return (
+        <>
+            {arbeidssokerperioder.antallDagerSidenSisteArbeidssokerperiode < 28 && <ReaktiveringWrapper />}
+            {underOppfolging ? (
+                <ArbeidssokerDataProvider>
+                    <InnholdUnderOppfolgingUtenPeriode />
+                </ArbeidssokerDataProvider>
+            ) : (
+                <IkkeRegistrert />
+            )}
+        </>
+    );
 }
 
 export default IkkeArbeidssokerInnhold;


### PR DESCRIPTION
Hvis brukeren ikke er arbeidssøker, men er under oppfølging, skal vi fortsatt vise aktivitetsplan, info om meldekort osv. Vi hadde en bug hvor dette ikke ble vist hvis brukeren avsluttet arbeidssøkerperioden sin for under 28 dager siden. Vi viste da bare en advarsel om at de ikke lenger er registrert. Har endret dette så vi både viser advarselen og resten av informasjonen de skal se.