### PR TITLE
Legg til melderkortdata i amplitudeprovider

### DIFF
--- a/src/contexts/amplitude-context.ts
+++ b/src/contexts/amplitude-context.ts
@@ -2,8 +2,9 @@ import { createContext, useContext } from 'react';
 import { AmplitudeData } from '../metrics/amplitude-utils';
 import { InnloggingsNiva } from './autentisering';
 import { DinSituasjonSvar } from './brukerregistrering';
+import { Data as MeldekortData } from '../hooks/use-meldekortdata';
 
-export const initialState: AmplitudeData = {
+export const initialAmplitudeData: AmplitudeData = {
     brukergruppe: 'ukjent',
     geografiskTilknytning: 'INGEN_VERDI',
     ukerRegistrert: 'INGEN_DATO',
@@ -27,9 +28,14 @@ export const initialState: AmplitudeData = {
     antallDagerSidenSisteArbeidssokerperiode: 'INGEN_DATA',
     antallUkerSidenSisteArbeidssokerperiode: 'INGEN_DATA',
     antallUkerMellomSisteArbeidssokerperioder: 'INGEN_DATA',
+    meldegruppe: 'INGEN_VERDI',
+    antallMeldekortKlareForLevering: 0,
 };
 
-const AmplitudeContext = createContext<AmplitudeData>(initialState);
+const AmplitudeContext = createContext({
+    amplitudeData: initialAmplitudeData,
+    setMeldekortData: (meldekortData: MeldekortData) => {},
+});
 
 function useAmplitudeData() {
     const context = useContext(AmplitudeContext);

--- a/src/hooks/use-meldekortdata.ts
+++ b/src/hooks/use-meldekortdata.ts
@@ -1,5 +1,7 @@
 import { DataElement, NESTE_MELDEKORT_URL } from '../ducks/api';
 import { useSWR } from './useSWR';
+import { useAmplitudeData } from '../contexts/amplitude-context';
+import { useEffect } from 'react';
 
 export interface State extends DataElement {
     data: Data | null;
@@ -25,6 +27,14 @@ export interface Data {
 
 export function useMeldekortData() {
     const { data, error } = useSWR<Data>(NESTE_MELDEKORT_URL);
+    const { setMeldekortData } = useAmplitudeData();
+
+    useEffect(() => {
+        if (data) {
+            setMeldekortData(data);
+        }
+    }, [data]);
+
     return {
         meldekortData: data,
         isLoading: !error && !data,

--- a/src/innhold/innhold-metrics.tsx
+++ b/src/innhold/innhold-metrics.tsx
@@ -31,7 +31,7 @@ function Metrics(props: Props) {
     const oppfolgingData = useOppfolgingData();
     const { formidlingsgruppe, servicegruppe, kanReaktiveres } = oppfolgingData;
 
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
 
     const registreringData = useBrukerregistreringData();
     const { alder } = useBrukerinfoData();

--- a/src/komponenter/aktivitetsplan/aktivitetsplan.tsx
+++ b/src/komponenter/aktivitetsplan/aktivitetsplan.tsx
@@ -25,7 +25,7 @@ const TEKSTER = {
     },
 };
 const Aktivitetsplan = () => {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const tekst = lagHentTekstForSprak(TEKSTER, useSprakValg().sprak);
 
     const handleClick = () => {

--- a/src/komponenter/dagpenger/dagpenger-har-ikke-sokt.tsx
+++ b/src/komponenter/dagpenger/dagpenger-har-ikke-sokt.tsx
@@ -24,7 +24,7 @@ const TEKSTER: Tekster<string> = {
 };
 
 const DagpengerHarIkkeSokt = () => {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const tekst = lagHentTekstForSprak(TEKSTER, useSprakValg().sprak);
 
     const handleButtonClick = () => {

--- a/src/komponenter/dagpenger/dagpenger-har-paabegynt-soknad.tsx
+++ b/src/komponenter/dagpenger/dagpenger-har-paabegynt-soknad.tsx
@@ -32,7 +32,7 @@ const TEKSTER: Tekster<string> = {
 
 const DagpengerHarPaabegyntSoknad = () => {
     const { data: paabegynteSoknaderData = [] } = useSWR<DpInnsynPaabegyntSoknad[]>(`${DP_INNSYN_URL}/paabegynte`);
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
 
     const sistePabegynteSoknad = paabegynteSoknaderData.sort(
         (a: DpInnsynPaabegyntSoknad, b: DpInnsynPaabegyntSoknad) =>

--- a/src/komponenter/dagpenger/dagpenger-og-ytelser.tsx
+++ b/src/komponenter/dagpenger/dagpenger-og-ytelser.tsx
@@ -11,7 +11,7 @@ function DagpengerOgYtelser() {
     const YTELSER_TEMA_VIS_KEY = 'ytelser_tema_vis_key';
     const YTELSER_VISNING_PROFIL_KEY = hentProfilnokkelFraLocalStorage(YTELSER_TEMA_VIS_KEY);
 
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const { profil, lagreProfil } = useProfil();
 
     const valgtVisningFraProfil = profil?.[YTELSER_VISNING_PROFIL_KEY];

--- a/src/komponenter/dagpenger/ettersend-dokumentasjon.tsx
+++ b/src/komponenter/dagpenger/ettersend-dokumentasjon.tsx
@@ -23,7 +23,7 @@ const TEKSTER: Tekster<string> = {
 };
 
 const EttersendDokumentasjon = ({ amplitudeTemaNavn }: Props) => {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const tekst = lagHentTekstForSprak(TEKSTER, useSprakValg().sprak);
 
     function loggLenkeKlikk(action: string, url: string) {

--- a/src/komponenter/dagpenger/les-om-ytelser.tsx
+++ b/src/komponenter/dagpenger/les-om-ytelser.tsx
@@ -20,7 +20,7 @@ const TEKSTER: Tekster<string> = {
 };
 
 const LesOmYtelser = ({ amplitudeTemaNavn }: Props) => {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const tekst = lagHentTekstForSprak(TEKSTER, useSprakValg().sprak);
 
     function loggLenkeKlikk(action: string, url: string) {

--- a/src/komponenter/dagpenger/paabegynte-soknader.tsx
+++ b/src/komponenter/dagpenger/paabegynte-soknader.tsx
@@ -22,7 +22,7 @@ const TEKSTER = {
 };
 
 const PaabegynteSoknader = ({ dato, komponent }: { dato?: string; komponent: string }) => {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const { data: paabegynteSoknader = [] } = useSWR<DpInnsynPaabegyntSoknad[]>(`${DP_INNSYN_URL}/paabegynte`);
     const tekst = lagHentTekstForSprak(TEKSTER, useSprakValg().sprak);
 

--- a/src/komponenter/dagpenger/sist-innsendt-soknad.tsx
+++ b/src/komponenter/dagpenger/sist-innsendt-soknad.tsx
@@ -27,7 +27,7 @@ const TEKSTER = {
 
 const SistInnsendtSoknad = ({ dato, komponent }: { dato?: string; komponent: string }) => {
     const { data: soknader = [] } = useSWR<DpInnsynSoknad[]>(`${DP_INNSYN_URL}/soknad`);
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const sprak = useSprakValg().sprak;
     const tekst = lagHentTekstForSprak(TEKSTER, sprak);
 

--- a/src/komponenter/dagpenger/skriv-til-oss-chat-og-mine-dagpenger.tsx
+++ b/src/komponenter/dagpenger/skriv-til-oss-chat-og-mine-dagpenger.tsx
@@ -32,7 +32,7 @@ interface Props {
 
 const SkrivTilOssChatOgMineDagpenger = (props: Props) => {
     const { amplitudeTemaNavn } = props;
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const tekst = lagHentTekstForSprak(TEKSTER, useSprakValg().sprak);
 
     function loggLenkeKlikk(action: string, url: string) {

--- a/src/komponenter/dagpenger/ytelser.tsx
+++ b/src/komponenter/dagpenger/ytelser.tsx
@@ -29,7 +29,7 @@ const TEKSTER: Tekster<string> = {
     },
 };
 const Ytelser = () => {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
 
     function loggLenkeKlikk(action: string, url: string) {
         loggAktivitet({ aktivitet: action, ...amplitudeData });

--- a/src/komponenter/er-rendret/er-rendret.tsx
+++ b/src/komponenter/er-rendret/er-rendret.tsx
@@ -8,7 +8,7 @@ type Props = {
 };
 
 function ErRendret(props: Props) {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
 
     useEffect(() => {
         loggRendring({ rendrer: props.loggTekst, ...amplitudeData });

--- a/src/komponenter/feedback/feedback-profil.tsx
+++ b/src/komponenter/feedback/feedback-profil.tsx
@@ -54,7 +54,7 @@ function Feedback({ id, className, sporsmal }: Props) {
     const [oppdatert, setOppdatert] = useState('');
     const [visPopover, setVisPopover] = useState<HTMLElement | undefined>(undefined);
     const feedbackNeiKnappRef = useRef(null);
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
 
     const tekst = lagHentTekstForSprak(TEKSTER, useSprakValg().sprak);
 

--- a/src/komponenter/gjelder-fra-dato/GjelderFraDato.tsx
+++ b/src/komponenter/gjelder-fra-dato/GjelderFraDato.tsx
@@ -10,7 +10,7 @@ import { useAmplitudeData } from '../../contexts/amplitude-context';
 import { useGjelderFraDato } from '../../contexts/gjelder-fra-dato';
 
 function GjelderFraDato(): JSX.Element | null {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const { visModal, settLukkModal } = useGjelderFraDatoModal();
     const featureToggleData = useFeatureToggleData();
     const registreringData = useBrukerregistreringData();

--- a/src/komponenter/hjelp-og-stotte/egenvurdering-uke12.tsx
+++ b/src/komponenter/hjelp-og-stotte/egenvurdering-uke12.tsx
@@ -33,7 +33,7 @@ const TEKSTER = {
 };
 
 function EgenvurderingUke12() {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const { ukerRegistrert } = amplitudeData;
     const { lagreProfil } = useProfil();
 

--- a/src/komponenter/hjelp-og-stotte/egenvurderingIVURD.tsx
+++ b/src/komponenter/hjelp-og-stotte/egenvurderingIVURD.tsx
@@ -35,7 +35,7 @@ const TEKSTER = {
 };
 
 const EgenvurderingIVURD = () => {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const { lagreProfil } = useProfil();
 
     const lagreEgenvurderingDato = () => {

--- a/src/komponenter/hjelp-og-stotte/forklaring-engelsk.tsx
+++ b/src/komponenter/hjelp-og-stotte/forklaring-engelsk.tsx
@@ -26,7 +26,7 @@ function Avsnitt1Engelsk() {
 
 function Avsnitt2Engelsk() {
     const { servicegruppe } = useContext(OppfolgingContext).data;
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
 
     const handleLesBrev = () => {
         amplitudeLogger('veientilarbeid.intro', {
@@ -63,7 +63,7 @@ function Avsnitt2Engelsk() {
 }
 
 function Avsnitt3Engelsk() {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
 
     function loggLenkeKlikk(handling: string, url: string) {
         amplitudeLogger('veientilarbeid.intro', {

--- a/src/komponenter/hjelp-og-stotte/forklaring-norsk.tsx
+++ b/src/komponenter/hjelp-og-stotte/forklaring-norsk.tsx
@@ -26,7 +26,7 @@ function Avsnitt1() {
 
 function Avsnitt2() {
     const { servicegruppe } = useContext(OppfolgingContext).data;
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
 
     const handleLesBrev = () => {
         amplitudeLogger('veientilarbeid.intro', {
@@ -60,7 +60,7 @@ function Avsnitt2() {
 }
 
 function Avsnitt3() {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
 
     function loggLenkeKlikk(handling: string, url: string) {
         amplitudeLogger('veientilarbeid.intro', {

--- a/src/komponenter/hjelp-og-stotte/forklaring-ungdom-engelsk.tsx
+++ b/src/komponenter/hjelp-og-stotte/forklaring-ungdom-engelsk.tsx
@@ -41,7 +41,7 @@ function Avsnitt2() {
 }
 
 function Avsnitt3() {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
 
     function loggLenkeKlikk(handling: string, url: string) {
         amplitudeLogger('veientilarbeid.intro', {
@@ -99,7 +99,7 @@ function Avsnitt3() {
 
 function Avsnitt4() {
     const { servicegruppe } = useContext(OppfolgingContext).data;
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
 
     const handleLesBrev = () => {
         amplitudeLogger('veientilarbeid.intro', {

--- a/src/komponenter/hjelp-og-stotte/forklaring-ungdom-norsk.tsx
+++ b/src/komponenter/hjelp-og-stotte/forklaring-ungdom-norsk.tsx
@@ -42,7 +42,7 @@ function Avsnitt2() {
 }
 
 function Avsnitt3() {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
 
     function loggLenkeKlikk(handling: string, url: string) {
         amplitudeLogger('veientilarbeid.intro', {
@@ -100,7 +100,7 @@ function Avsnitt3() {
 
 function Avsnitt4() {
     const { servicegruppe } = useContext(OppfolgingContext).data;
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
 
     const handleLesBrev = () => {
         amplitudeLogger('veientilarbeid.intro', {

--- a/src/komponenter/hjelp-og-stotte/hjelp-og-stotte.tsx
+++ b/src/komponenter/hjelp-og-stotte/hjelp-og-stotte.tsx
@@ -47,7 +47,7 @@ const TEKSTER = {
 
 function HjelpOgStotte() {
     const [clickedLesMer, setClickedLesMer] = useState(false);
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const { ukerRegistrert } = amplitudeData;
 
     const registreringData = useBrukerregistreringData();

--- a/src/komponenter/ikke-registrert/ikke-registrert.tsx
+++ b/src/komponenter/ikke-registrert/ikke-registrert.tsx
@@ -29,7 +29,7 @@ const IkkeRegistrert = () => {
     const harRegistreringUrlParameter = goto === 'registrering';
     const infoBoksRef = useRef<HTMLDivElement>(null);
 
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const tekst = lagHentTekstForSprak(TEKSTER, useSprakValg().sprak);
 
     const handleButtonClick = () => {

--- a/src/komponenter/ikke-standard/egenvurdering.tsx
+++ b/src/komponenter/ikke-standard/egenvurdering.tsx
@@ -23,7 +23,7 @@ const TEKSTER: Tekster<string> = {
 };
 
 const Egenvurdering = () => {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const registreringData = useBrukerregistreringData();
     const egenvurderingData = useEgenvurderingData();
     const oppfolgingData = useOppfolgingData();

--- a/src/komponenter/ikke-standard/ikke-standard.tsx
+++ b/src/komponenter/ikke-standard/ikke-standard.tsx
@@ -72,7 +72,7 @@ const ListeElement = (ikon: JSX.Element, innhold: JSX.Element) => {
 
 function IkkeStandard() {
     const tekst = lagHentTekstForSprak(TEKSTER, useSprakValg().sprak);
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const { erSykmeldtMedArbeidsgiver } = useBrukerinfoData();
 
     const handleClick = (action: string) => {

--- a/src/komponenter/ikke-standard/motestotte.tsx
+++ b/src/komponenter/ikke-standard/motestotte.tsx
@@ -36,7 +36,7 @@ const TEKSTER: Tekster<string> = {
 };
 
 const Motestotte = () => {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const data = useBrukerregistreringData();
     const oppfolgingData = useOppfolgingData();
     const motestotteData = useMotestotteData();

--- a/src/komponenter/in-viewport/in-viewport.tsx
+++ b/src/komponenter/in-viewport/in-viewport.tsx
@@ -17,7 +17,7 @@ const WrappedViewport: React.ComponentType<Props> = handleViewport(InViewport);
 
 function InViewport(props: Props & ViewportProps): JSX.Element {
     const [harVistTilBruker, setHarVistTilBruker] = useState<boolean>(false);
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
 
     if (props.inViewport && !harVistTilBruker) {
         setHarVistTilBruker(true);

--- a/src/komponenter/innsyn/innsyn-les-mer.tsx
+++ b/src/komponenter/innsyn/innsyn-les-mer.tsx
@@ -27,7 +27,7 @@ const InnsynLesMer = () => {
     const tekst = lagHentTekstForSprak(TEKSTER, useSprakValg().sprak);
     const brukerregistreringData = useBrukerregistreringData();
     const arbeidssokerperiodeData = useArbeidssokerPerioder();
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const { harAktivArbeidssokerperiode, aktivPeriodeStart } = beregnArbeidssokerperioder(arbeidssokerperiodeData);
     const { opprettetDato, manueltRegistrertAv, besvarelse, teksterForBesvarelse, sisteStilling } =
         brukerregistreringData?.registrering || {};

--- a/src/komponenter/kvitteringer/kvittering-egenvurdering.tsx
+++ b/src/komponenter/kvitteringer/kvittering-egenvurdering.tsx
@@ -86,7 +86,7 @@ function Kvittering(props: KvitteringProps) {
 }
 
 function KvitteringEgenvurdering() {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const [kvittering, setKvittering] = useState('');
     const [visKomponent, setVisKomponent] = useState(true);
 

--- a/src/komponenter/meldekort/meldekort-knapp.tsx
+++ b/src/komponenter/meldekort/meldekort-knapp.tsx
@@ -4,7 +4,6 @@ import { Button } from '@navikt/ds-react';
 import spacingStyles from '../../spacing.module.css';
 
 import { useAmplitudeData } from '../../contexts/amplitude-context';
-
 import { amplitudeLogger } from '../../metrics/amplitude-utils';
 
 interface TemaLenkepanelProps {
@@ -17,7 +16,7 @@ interface TemaLenkepanelProps {
 }
 
 const MeldekortKnapp: React.FC<TemaLenkepanelProps> = (props) => {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
 
     const handleClickInnsending = () => {
         amplitudeLogger('veientilarbeid.tema', {

--- a/src/komponenter/meldekort/meldekort.tsx
+++ b/src/komponenter/meldekort/meldekort.tsx
@@ -23,7 +23,7 @@ const TEKSTER = {
 
 function Meldekort() {
     const [clickedLesMer, setClickedLesMer] = useState(false);
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const sprak = useSprakValg().sprak;
     const tekst = lagHentTekstForSprak(TEKSTER, sprak);
 

--- a/src/komponenter/reaktivering/reaktivering-ikke-aktuelt-melding.tsx
+++ b/src/komponenter/reaktivering/reaktivering-ikke-aktuelt-melding.tsx
@@ -8,7 +8,7 @@ import { BodyShort, Button, Link } from '@navikt/ds-react';
 import spacingStyles from '../../spacing.module.css';
 
 const ReaktiveringIkkeAktueltMelding = () => {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const { kanReaktiveres } = React.useContext(OppfolgingContext).data;
     const { securityLevel } = useAutentiseringData();
     const isLevel4 = securityLevel === InnloggingsNiva.LEVEL_4;

--- a/src/komponenter/reaktivering/reaktivering-kvittering.tsx
+++ b/src/komponenter/reaktivering/reaktivering-kvittering.tsx
@@ -40,7 +40,7 @@ const TEKSTER = {
 };
 
 const ReaktiveringKvittering = () => {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const [visKomponent, setVisKonponent] = useState(false);
     const visKvittering = useVisKvittering('reaktivering');
     const tekst = lagHentTekstForSprak(TEKSTER, useSprakValg().sprak);

--- a/src/komponenter/reaktivering/reaktivering-melding.tsx
+++ b/src/komponenter/reaktivering/reaktivering-melding.tsx
@@ -18,7 +18,7 @@ type Props = {
 };
 
 const ReaktiveringMelding = (props: Props & ViewportProps): JSX.Element | null => {
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
     const { kanReaktiveres } = React.useContext(OppfolgingContext).data;
     const { securityLevel } = useAutentiseringData();
 

--- a/src/komponenter/reaktivering/reaktivering.tsx
+++ b/src/komponenter/reaktivering/reaktivering.tsx
@@ -36,7 +36,7 @@ const Reaktivering = () => {
     const reaktiveringVisning = bestemReaktiveringVisning(valgtReaktiveringVisning);
     const [visReaktiveringAdvarsel, setVisReaktiveringAdvarsel] = React.useState(reaktiveringVisning);
 
-    const amplitudeData = useAmplitudeData();
+    const { amplitudeData } = useAmplitudeData();
 
     const handleReaktivering = (aktivitet: string) => {
         loggAktivitet({ aktivitet: aktivitet, ...amplitudeData });

--- a/src/metrics/amplitude-utils.ts
+++ b/src/metrics/amplitude-utils.ts
@@ -54,6 +54,8 @@ export type AmplitudeData = {
     antallDagerSidenSisteArbeidssokerperiode: number | 'INGEN_DATA' | 'N/A' | 'Ikke avsluttet';
     antallUkerSidenSisteArbeidssokerperiode: number | 'INGEN_DATA' | 'N/A' | 'Ikke avsluttet';
     antallUkerMellomSisteArbeidssokerperioder: number | 'INGEN_DATA' | 'N/A' | 'Første periode';
+    meldegruppe: string;
+    antallMeldekortKlareForLevering: number;
 };
 
 export function amplitudeLogger(name: string, values?: object) {


### PR DESCRIPTION
Meldekortdata blir ikke hentet inn for alle brukere lenger, og ble derfor fjernet fra amplitudeData. Legger disse feltene til igjen fordi vi ønsker å ha dem med hvis de fins + hook for å sette verdiene når de blir henta.