### PR TITLE
Dev/behovsvurdering v2

### DIFF
--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-avklart-standard.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-avklart-standard.tsx
@@ -15,7 +15,7 @@ import { AktivitetsplanLenke, GaaTilDialogKnapp } from './lenker';
 const TEKSTER = {
     nb: {
         overskrift: 'Hjelp og støtte',
-        headingEnig: 'Du har gode muligheter til å klare deg selv',
+        headingEnig: 'Du har gode muligheter til å komme i jobb uten en veileder eller tiltak fra NAV',
         headingUenig: 'Du har sagt at du ønsker hjelp',
         beskrivelseEnig: 'Du har ansvar for å aktivt lete etter jobber og å søke på relevante stillinger på egen hånd.',
         hvaTenkerDu: 'Hva tenker du?',

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-avklart-standard.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-avklart-standard.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from '@navikt/ds-icons';
-import { BodyLong, Detail, Heading, Panel, ReadMore } from '@navikt/ds-react';
+import { BodyLong, Detail, Heading, Panel } from '@navikt/ds-react';
 
 import { useSprakValg } from '../../contexts/sprak';
 
@@ -10,18 +10,17 @@ import InViewport from '../in-viewport/in-viewport';
 
 import spacingStyles from '../../spacing.module.css';
 import flexStyles from '../../flex.module.css';
-import { AktivitetsplanLenke, DialogLenke, GaaTilDialogKnapp } from './lenker';
+import { AktivitetsplanLenke, GaaTilDialogKnapp } from './lenker';
 
 const TEKSTER = {
     nb: {
         overskrift: 'Hjelp og støtte',
         headingEnig: 'Du har gode muligheter til å klare deg selv',
         headingUenig: 'Du har sagt at du ønsker hjelp',
-        beskrivelseEnig: 'Du har ansvar for å aktivt lete etter jobber og å søke på relevante stillinger på egenhånd.',
+        beskrivelseEnig: 'Du har ansvar for å aktivt lete etter jobber og å søke på relevante stillinger på egen hånd.',
         hvaTenkerDu: 'Hva tenker du?',
         klareDegSelv: 'Ønsker du å klare deg selv?',
-        readMoreHeadingEnig: 'Gi beskjed dersom du likevel ønsker veiledning',
-        readMoreInnholdEnig: 'Du kan når som helst ta kontakt for å starte samhandling med en veileder.',
+        behovForVeiledningLikevel: 'Gi beskjed i dialogen dersom du likevel har behov for veiledning.',
     },
     en: {
         heading: 'Get in touch if you need help',
@@ -54,14 +53,11 @@ function BehovsavklaringAvklartStandard() {
                     {tekst('headingEnig')}
                 </Heading>
                 <BodyLong className={spacingStyles.mb1}>{tekst('beskrivelseEnig')}</BodyLong>
-                <ReadMore size="medium" header={tekst('readMoreHeadingEnig')} className={spacingStyles.mb1}>
-                    <BodyLong className={spacingStyles.blokkXs}>{tekst('readMoreInnholdEnig')}</BodyLong>
-                    <GaaTilDialogKnapp />
-                </ReadMore>
-                <ReadMoreVeileder />
-                <BodyLong className={spacingStyles.mt1}>
-                    <DialogLenke aktivitet={'Behovsavklaring - avklart - standard - går til dialogen'} />
-                </BodyLong>
+                <BodyLong className={spacingStyles.blokkXs}>{tekst('behovForVeiledningLikevel')}</BodyLong>
+                <GaaTilDialogKnapp variant={'secondary'} />
+                <div className={spacingStyles.mt1}>
+                    <ReadMoreVeileder />
+                </div>
                 <BodyLong className={spacingStyles.mt1}>
                     <AktivitetsplanLenke
                         aktivitet={'Behovsavklaring - avklart - standard - går til aktivitetsplanen'}

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-ikke-svart-standard.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-ikke-svart-standard.tsx
@@ -89,7 +89,7 @@ function IkkeSvartPaaBehovsavklaringStandardInnsats() {
                     disabled={pendingRequest !== null}
                     loading={pendingRequest === ForeslattInnsatsgruppe.STANDARD_INNSATS}
                 >
-                    Ja, jeg tror jeg kan finne meg jobb uten en veileder
+                    Jeg klarer meg uten veileder
                 </Button>
                 <div className={spacingStyles.mb1}>
                     <Button
@@ -99,7 +99,7 @@ function IkkeSvartPaaBehovsavklaringStandardInnsats() {
                         variant="secondary"
                         className={`${spacingStyles.mt1}`}
                     >
-                        Nei, jeg trenger veiledning for å komme i arbeid
+                        Jeg trenger en veileder for å komme i arbeid
                     </Button>
                 </div>
                 <ReadMoreVurdering />

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-ikke-svart-standard.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-ikke-svart-standard.tsx
@@ -20,11 +20,12 @@ import { useAmplitudeData } from '../hent-initial-data/amplitude-provider';
 const TEKSTER = {
     nb: {
         overskrift: 'Hjelp og støtte',
-        heading: 'Hva slags veiledning ønsker du?',
+        heading: 'Klarer du å komme i arbeid uten hjelp fra NAV?',
         beskrivelse:
-            'Vi tror du har gode muligheter til å nå ditt mål om arbeid på egenhånd - uten hjelp fra veileder.',
+            'Vi tror du har gode muligheter til å komme i jobb uten arbeidsrettede tiltak fra NAV eller oppfølging fra en veileder.',
         hvaTenkerDu: 'Hva tenker du?',
-        klareDegSelv: 'Ønsker du å klare deg selv?',
+        klareDegSelv:
+            'En veileder kan gi arbeidsrettet oppfølging, men ikke svare på spørsmål om dagpenger eller meldekort.',
         readMoreHeading: 'Hva slags hjelp kan jeg få?',
         behovOverskrift: 'Mitt behov for veiledning',
         behovSvarEnig:
@@ -83,14 +84,14 @@ function IkkeSvartPaaBehovsavklaringStandardInnsats() {
                     {tekst('heading')}
                 </Heading>
                 <BodyLong className={`${spacingStyles.mb1}`}>{tekst('beskrivelse')}</BodyLong>
-                <BodyShort className={`${spacingStyles.mb1}`}>{tekst('hvaTenkerDu')}</BodyShort>
                 <BodyShort className={`${spacingStyles.mb1}`}>{tekst('klareDegSelv')}</BodyShort>
+                <BodyShort className={`${spacingStyles.mb1}`}>{tekst('hvaTenkerDu')}</BodyShort>
                 <Button
                     onClick={() => onClickBehovForVeiledning(ForeslattInnsatsgruppe.STANDARD_INNSATS)}
                     disabled={pendingRequest !== null}
                     loading={pendingRequest === ForeslattInnsatsgruppe.STANDARD_INNSATS}
                 >
-                    Ja, jeg ønsker å klare meg selv
+                    Ja, jeg tror jeg kan finne meg jobb uten en veileder
                 </Button>
                 <div className={spacingStyles.mb1}>
                     <Button
@@ -100,7 +101,7 @@ function IkkeSvartPaaBehovsavklaringStandardInnsats() {
                         variant="secondary"
                         className={`${spacingStyles.mt1}`}
                     >
-                        Nei, jeg har behov for veiledning
+                        Nei, jeg trenger veiledning for å komme i arbeid
                     </Button>
                 </div>
                 <ReadMoreVurdering />

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-ikke-svart-standard.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-ikke-svart-standard.tsx
@@ -21,7 +21,8 @@ const TEKSTER = {
     nb: {
         overskrift: 'Hjelp og støtte',
         heading: 'Vi tror du har gode muligheter til å komme i jobb uten en veileder eller tiltak fra NAV',
-        beskrivelse: 'En veileder kan hjelpe deg med å søke stillinger og finne aktuelle tiltak på veien til arbeid.',
+        beskrivelse:
+            'En veileders oppgave er å hjelpe deg med å søke stillinger og finne aktuelle tiltak på veien til arbeid.',
         hvaTenkerDu: 'Hva tenker du?',
         veilederKanIkke: 'En veileder kan ikke svare på spørsmål om dagpenger eller meldekort.',
         readMoreHeading: 'Hva slags hjelp kan jeg få?',

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-ikke-svart-standard.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-ikke-svart-standard.tsx
@@ -1,8 +1,10 @@
+import { useState } from 'react';
 import { Dialog } from '@navikt/ds-icons';
-import { BodyLong, BodyShort, Button, Detail, Heading, Panel } from '@navikt/ds-react';
+import { BodyLong, Button, Detail, Heading, Panel } from '@navikt/ds-react';
 
 import { useSprakValg } from '../../contexts/sprak';
 import { useBehovForVeiledning } from '../../contexts/behov-for-veiledning';
+import { useAmplitudeData } from '../hent-initial-data/amplitude-provider';
 
 import lagHentTekstForSprak from '../../lib/lag-hent-tekst-for-sprak';
 import { loggAktivitet } from '../../metrics/metrics';
@@ -14,18 +16,14 @@ import { ForeslattInnsatsgruppe } from '../../contexts/brukerregistrering';
 
 import spacingStyles from '../../spacing.module.css';
 import flexStyles from '../../flex.module.css';
-import { useState } from 'react';
-import { useAmplitudeData } from '../hent-initial-data/amplitude-provider';
 
 const TEKSTER = {
     nb: {
         overskrift: 'Hjelp og støtte',
-        heading: 'Klarer du å komme i arbeid uten hjelp fra NAV?',
-        beskrivelse:
-            'Vi tror du har gode muligheter til å komme i jobb uten arbeidsrettede tiltak fra NAV eller oppfølging fra en veileder.',
+        heading: 'Vi tror du har gode muligheter til å komme i jobb uten en veileder eller tiltak fra NAV',
+        beskrivelse: 'En veileder kan hjelpe deg med å søke stillinger og finne aktuelle tiltak på veien til arbeid.',
         hvaTenkerDu: 'Hva tenker du?',
-        klareDegSelv:
-            'En veileder kan gi arbeidsrettet oppfølging, men ikke svare på spørsmål om dagpenger eller meldekort.',
+        veilederKanIkke: 'En veileder kan ikke svare på spørsmål om dagpenger eller meldekort.',
         readMoreHeading: 'Hva slags hjelp kan jeg få?',
         behovOverskrift: 'Mitt behov for veiledning',
         behovSvarEnig:
@@ -84,8 +82,7 @@ function IkkeSvartPaaBehovsavklaringStandardInnsats() {
                     {tekst('heading')}
                 </Heading>
                 <BodyLong className={`${spacingStyles.mb1}`}>{tekst('beskrivelse')}</BodyLong>
-                <BodyShort className={`${spacingStyles.mb1}`}>{tekst('klareDegSelv')}</BodyShort>
-                <BodyShort className={`${spacingStyles.mb1}`}>{tekst('hvaTenkerDu')}</BodyShort>
+                <BodyLong className={`${spacingStyles.mb1}`}>{tekst('veilederKanIkke')}</BodyLong>
                 <Button
                     onClick={() => onClickBehovForVeiledning(ForeslattInnsatsgruppe.STANDARD_INNSATS)}
                     disabled={pendingRequest !== null}

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-svart-standard.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-svart-standard.tsx
@@ -9,16 +9,16 @@ import ReadMoreVeileder from './readmore-veileder';
 import ErRendret from '../er-rendret/er-rendret';
 import InViewport from '../in-viewport/in-viewport';
 import { ForeslattInnsatsgruppe } from '../../contexts/brukerregistrering';
+import { AktivitetsplanLenke, DialogLenke, GaaTilDialogKnapp } from './lenker';
 
 import spacingStyles from '../../spacing.module.css';
 import flexStyles from '../../flex.module.css';
-import { AktivitetsplanLenke, DialogLenke, GaaTilDialogKnapp } from './lenker';
 
 const TEKSTER = {
     nb: {
         overskrift: 'Hjelp og støtte',
         headingEnig: 'Du ønsker å klare deg selv',
-        headingUenig: 'Du har sagt at du ønsker hjelp',
+        headingUenig: 'Du har sagt at du ønsker hjelp fra en veileder',
         beskrivelseEnig: 'Du har ansvar for å aktivt lete etter jobber og å søke på relevante stillinger på egenhånd.',
         hvaTenkerDu: 'Hva tenker du?',
         klareDegSelv: 'Ønsker du å klare deg selv?',
@@ -100,18 +100,15 @@ function UenigMedProfilering() {
                     {tekst('headingUenig')}
                 </Heading>
                 <BodyLong className={spacingStyles.mb1}>
-                    En veileder vil ta stilling til hva slags hjelp du kan få. Du vil få et vedtaksbrev om dette.
-                </BodyLong>
-                <BodyLong className={spacingStyles.mb1}>
-                    Om du ønsker å skrive til veilederen om det du ønsker hjelp til kan du gjøre det via dialogen.
+                    Vi vil gjerne at du forteller oss mer om hva du trenger hjelp til.
                 </BodyLong>
                 <BodyLong className={spacingStyles.mb1}>
                     <GaaTilDialogKnapp />
                 </BodyLong>
-                <ReadMoreVeileder />
-                <BodyLong className={spacingStyles.mt1}>
-                    <DialogLenke aktivitet={'Behovsavklaring - svart - standard uenig - går til dialogen'} />
+                <BodyLong className={spacingStyles.mb1}>
+                    Etterpå vil vi ta stilling til hva slags hjelp vi kan tilby. Du vil få et vedtaksbrev om dette.
                 </BodyLong>
+                <ReadMoreVeileder />
                 <BodyLong className={spacingStyles.mt1}>
                     <AktivitetsplanLenke
                         aktivitet={'Behovsavklaring - svart - standard - uenig - går til aktivitetsplanen'}

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-svart-standard.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-svart-standard.tsx
@@ -21,6 +21,9 @@ const TEKSTER = {
         headingUenig: 'Du har sagt at du ønsker hjelp fra en veileder',
         beskrivelseEnig: 'Du har ansvar for å aktivt lete etter jobber og å søke på relevante stillinger på egen hånd.',
         behovForVeiledningLikevel: 'Gi beskjed i dialogen dersom du likevel har behov for veiledning.',
+        fortellMer: 'Vi vil gjerne at du forteller oss mer om hva du trenger hjelp til.',
+        hjelpOgVedtak:
+            'Etterpå vil vi ta stilling til hva slags hjelp vi kan tilby. Du vil få et vedtaksbrev om dette.',
     },
     en: {
         heading: 'Get in touch if you need help',
@@ -93,15 +96,11 @@ function UenigMedProfilering() {
                 <Heading className={spacingStyles.blokkXs} size="medium">
                     {tekst('headingUenig')}
                 </Heading>
-                <BodyLong className={spacingStyles.mb1}>
-                    Vi vil gjerne at du forteller oss mer om hva du trenger hjelp til.
-                </BodyLong>
+                <BodyLong className={spacingStyles.mb1}>{tekst('fortellMer')}</BodyLong>
                 <BodyLong className={spacingStyles.mb1}>
                     <GaaTilDialogKnapp />
                 </BodyLong>
-                <BodyLong className={spacingStyles.mb1}>
-                    Etterpå vil vi ta stilling til hva slags hjelp vi kan tilby. Du vil få et vedtaksbrev om dette.
-                </BodyLong>
+                <BodyLong className={spacingStyles.mb1}>{tekst('hjelpOgVedtak')}</BodyLong>
                 <ReadMoreVeileder />
                 <BodyLong className={spacingStyles.mt1}>
                     <AktivitetsplanLenke

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-svart-standard.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-svart-standard.tsx
@@ -17,13 +17,11 @@ import flexStyles from '../../flex.module.css';
 const TEKSTER = {
     nb: {
         overskrift: 'Hjelp og støtte',
-        headingEnig: 'Du ønsker å klare deg selv',
+        headingEnig: 'Du ønsker å klare deg uten veileder',
         headingUenig: 'Du har sagt at du ønsker hjelp fra en veileder',
         beskrivelseEnig: 'Du har ansvar for å aktivt lete etter jobber og å søke på relevante stillinger på egen hånd.',
         behovForVeiledningLikevel: 'Gi beskjed i dialogen dersom du likevel har behov for veiledning.',
-        fortellMer: 'Vi vil gjerne at du forteller oss mer om hva du trenger hjelp til.',
-        hjelpOgVedtak:
-            'Etterpå vil vi ta stilling til hva slags hjelp vi kan tilby. Du vil få et vedtaksbrev om dette.',
+        fortellMer: 'Fortell oss hva du trenger hjelp til for å komme i arbeid.',
     },
     en: {
         heading: 'Get in touch if you need help',

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-svart-standard.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-svart-standard.tsx
@@ -20,7 +20,7 @@ const TEKSTER = {
         headingEnig: 'Du ønsker å klare deg selv',
         headingUenig: 'Du har sagt at du ønsker hjelp fra en veileder',
         beskrivelseEnig: 'Du har ansvar for å aktivt lete etter jobber og å søke på relevante stillinger på egenhånd.',
-        behovForVeiledning: 'Gi beskjed i dialogen dersom du likevel har behov for veiledning.',
+        behovForVeiledningLikevel: 'Gi beskjed i dialogen dersom du likevel har behov for veiledning.',
     },
     en: {
         heading: 'Get in touch if you need help',
@@ -53,7 +53,7 @@ function EnigMedProfilering() {
                     {tekst('headingEnig')}
                 </Heading>
                 <BodyLong className={spacingStyles.mb1}>{tekst('beskrivelseEnig')}</BodyLong>
-                <BodyLong className={spacingStyles.blokkXs}>{tekst('kontaktMedVeileder')}</BodyLong>
+                <BodyLong className={spacingStyles.blokkXs}>{tekst('behovForVeiledningLikevel')}</BodyLong>
                 <GaaTilDialogKnapp variant={'secondary'} />
                 <div className={spacingStyles.mt1}>
                     <ReadMoreVeileder />

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-svart-standard.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-svart-standard.tsx
@@ -19,7 +19,7 @@ const TEKSTER = {
         overskrift: 'Hjelp og støtte',
         headingEnig: 'Du ønsker å klare deg selv',
         headingUenig: 'Du har sagt at du ønsker hjelp fra en veileder',
-        beskrivelseEnig: 'Du har ansvar for å aktivt lete etter jobber og å søke på relevante stillinger på egenhånd.',
+        beskrivelseEnig: 'Du har ansvar for å aktivt lete etter jobber og å søke på relevante stillinger på egen hånd.',
         behovForVeiledningLikevel: 'Gi beskjed i dialogen dersom du likevel har behov for veiledning.',
     },
     en: {

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-svart-standard.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-svart-standard.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from '@navikt/ds-icons';
-import { BodyLong, Detail, Heading, Panel, ReadMore } from '@navikt/ds-react';
+import { BodyLong, Detail, Heading, Panel } from '@navikt/ds-react';
 
 import { useSprakValg } from '../../contexts/sprak';
 import { useBehovForVeiledning } from '../../contexts/behov-for-veiledning';
@@ -9,7 +9,7 @@ import ReadMoreVeileder from './readmore-veileder';
 import ErRendret from '../er-rendret/er-rendret';
 import InViewport from '../in-viewport/in-viewport';
 import { ForeslattInnsatsgruppe } from '../../contexts/brukerregistrering';
-import { AktivitetsplanLenke, DialogLenke, GaaTilDialogKnapp } from './lenker';
+import { AktivitetsplanLenke, GaaTilDialogKnapp } from './lenker';
 
 import spacingStyles from '../../spacing.module.css';
 import flexStyles from '../../flex.module.css';
@@ -20,10 +20,7 @@ const TEKSTER = {
         headingEnig: 'Du ønsker å klare deg selv',
         headingUenig: 'Du har sagt at du ønsker hjelp fra en veileder',
         beskrivelseEnig: 'Du har ansvar for å aktivt lete etter jobber og å søke på relevante stillinger på egenhånd.',
-        hvaTenkerDu: 'Hva tenker du?',
-        klareDegSelv: 'Ønsker du å klare deg selv?',
-        readMoreHeadingEnig: 'Gi beskjed dersom du likevel ønsker veiledning',
-        readMoreInnholdEnig: 'Du kan når som helst ta kontakt for å starte samhandling med en veileder.',
+        behovForVeiledning: 'Gi beskjed i dialogen dersom du likevel har behov for veiledning.',
     },
     en: {
         heading: 'Get in touch if you need help',
@@ -56,14 +53,11 @@ function EnigMedProfilering() {
                     {tekst('headingEnig')}
                 </Heading>
                 <BodyLong className={spacingStyles.mb1}>{tekst('beskrivelseEnig')}</BodyLong>
-                <ReadMore size="medium" header={tekst('readMoreHeadingEnig')} className={spacingStyles.mb1}>
-                    <BodyLong className={spacingStyles.mb1}>{tekst('readMoreInnholdEnig')}</BodyLong>
-                    <GaaTilDialogKnapp />
-                </ReadMore>
-                <ReadMoreVeileder />
-                <BodyLong className={spacingStyles.mt1}>
-                    <DialogLenke aktivitet={'Behovsavklaring - svart - standard - enig - går til dialogen'} />
-                </BodyLong>
+                <BodyLong className={spacingStyles.blokkXs}>{tekst('kontaktMedVeileder')}</BodyLong>
+                <GaaTilDialogKnapp variant={'secondary'} />
+                <div className={spacingStyles.mt1}>
+                    <ReadMoreVeileder />
+                </div>
                 <BodyLong className={spacingStyles.mt1}>
                     <AktivitetsplanLenke
                         aktivitet={'Behovsavklaring - svart - standard - enig - går til aktivitetsplanen'}

--- a/src/komponenter/behovsavklaring-oppfolging/lenker.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/lenker.tsx
@@ -12,7 +12,8 @@ import { useAmplitudeData } from '../hent-initial-data/amplitude-provider';
 
 const TEKSTER = {
     nb: {
-        gaTilDialog: 'Skriv til veilederen',
+        gaTilDialogKnapp: 'Skriv til veilederen',
+        gaTilDialogLenke: 'Gå til dialogen',
         gaTilAktivitetsplan: 'Gå til din aktivitetsplan',
         ulest_melding: 'ulest melding',
         uleste_meldinger: 'uleste meldinger',
@@ -70,7 +71,7 @@ export const DialogLenke = (props: LenkeProps) => {
                     ...amplitudeData,
                 })}
             >
-                {tekst('gaTilDialog')}
+                {tekst('gaTilDialogLenke')}
             </Link>
             {antallUleste > 0 && (
                 <span className={`${spacingStyles.ml05} navds-body-short navds-body-short--small`}>
@@ -102,7 +103,7 @@ export const GaaTilDialogKnapp = (props: GaaTilDialogKnappProps) => {
     const { behovForVeiledning } = useBehovForVeiledning();
     return (
         <Button onClick={onClickDialogKnapp(behovForVeiledning, amplitudeData)}>
-            {props.tekst || tekst('gaTilDialog')}
+            {props.tekst || tekst('gaTilDialogKnapp')}
         </Button>
     );
 };

--- a/src/komponenter/behovsavklaring-oppfolging/lenker.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/lenker.tsx
@@ -12,7 +12,7 @@ import { useAmplitudeData } from '../hent-initial-data/amplitude-provider';
 
 const TEKSTER = {
     nb: {
-        gaTilDialog: 'Gå til dialogen',
+        gaTilDialog: 'Skriv til veilederen',
         gaTilAktivitetsplan: 'Gå til din aktivitetsplan',
         ulest_melding: 'ulest melding',
         uleste_meldinger: 'uleste meldinger',

--- a/src/komponenter/behovsavklaring-oppfolging/lenker.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/lenker.tsx
@@ -1,14 +1,17 @@
+import { MouseEventHandler } from 'react';
 import { Button, Link } from '@navikt/ds-react';
-import { aktivitetsplanLenke, dialogLenke } from '../../innhold/lenker';
+
 import { useSprakValg } from '../../contexts/sprak';
+import { useUlesteDialogerData } from '../../contexts/ulestedialoger';
+import { useAmplitudeData } from '../hent-initial-data/amplitude-provider';
+
+import { aktivitetsplanLenke, dialogLenke } from '../../innhold/lenker';
 import lagHentTekstForSprak from '../../lib/lag-hent-tekst-for-sprak';
 import { AmplitudeStandardAktivitetsData, loggAktivitet } from '../../metrics/metrics';
-import { MouseEventHandler } from 'react';
 import { BehovForVeiledningResponse, useBehovForVeiledning } from '../../contexts/behov-for-veiledning';
 import { AmplitudeData } from '../../metrics/amplitude-utils';
-import { useUlesteDialogerData } from '../../contexts/ulestedialoger';
+
 import spacingStyles from '../../spacing.module.css';
-import { useAmplitudeData } from '../hent-initial-data/amplitude-provider';
 
 const TEKSTER = {
     nb: {

--- a/src/komponenter/behovsavklaring-oppfolging/lenker.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/lenker.tsx
@@ -95,6 +95,7 @@ function onClickDialogKnapp(behovForVeiledning: BehovForVeiledningResponse, ampl
 
 interface GaaTilDialogKnappProps {
     tekst?: string;
+    variant?: 'primary' | 'secondary';
 }
 export const GaaTilDialogKnapp = (props: GaaTilDialogKnappProps) => {
     const sprak = useSprakValg().sprak;
@@ -102,7 +103,7 @@ export const GaaTilDialogKnapp = (props: GaaTilDialogKnappProps) => {
     const { amplitudeData } = useAmplitudeData();
     const { behovForVeiledning } = useBehovForVeiledning();
     return (
-        <Button onClick={onClickDialogKnapp(behovForVeiledning, amplitudeData)}>
+        <Button variant={props.variant} onClick={onClickDialogKnapp(behovForVeiledning, amplitudeData)}>
             {props.tekst || tekst('gaTilDialogKnapp')}
         </Button>
     );

--- a/src/komponenter/behovsavklaring-oppfolging/readmore-veileder.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/readmore-veileder.tsx
@@ -1,60 +1,19 @@
 import { useState } from 'react';
-import { BodyShort, Link, ReadMore } from '@navikt/ds-react';
+import { BodyShort, ReadMore } from '@navikt/ds-react';
 
-import { amplitudeLogger, AmplitudeData } from '../../metrics/amplitude-utils';
+import { useAmplitudeData } from '../hent-initial-data/amplitude-provider';
+
+import { AmplitudeData } from '../../metrics/amplitude-utils';
 import { loggAktivitet } from '../../metrics/metrics';
+import STOogChat from './sto-og-chat';
 
 import spacingStyles from '../../spacing.module.css';
-import { useAmplitudeData } from '../hent-initial-data/amplitude-provider';
 
 interface Props {
     amplitudeData: AmplitudeData;
 }
 
 function Innhold(props: Props) {
-    const { amplitudeData } = props;
-
-    function loggLenkeKlikk(handling: string, url: string) {
-        amplitudeLogger('veientilarbeid.intro', {
-            intro: '14a',
-            handling,
-            ...amplitudeData,
-        });
-        window.location.assign(url);
-    }
-
-    function SkrivTilOss() {
-        return (
-            <Link
-                href="https://mininnboks.nav.no/sporsmal/skriv/ARBD"
-                onClick={() =>
-                    loggLenkeKlikk(
-                        'Går til STO fra 14a onboarding kort',
-                        'https://mininnboks.nav.no/sporsmal/skriv/ARBD'
-                    )
-                }
-            >
-                skriv til oss
-            </Link>
-        );
-    }
-
-    function Chat() {
-        return (
-            <Link
-                href="https://www.nav.no/person/kontakt-oss/chat/"
-                onClick={() =>
-                    loggLenkeKlikk(
-                        'Går til Chat fra 14a onboarding kort',
-                        'https://www.nav.no/person/kontakt-oss/chat/'
-                    )
-                }
-            >
-                chat
-            </Link>
-        );
-    }
-
     return (
         <div className={spacingStyles.mt1}>
             <BodyShort className={spacingStyles.blokkXs}>
@@ -64,12 +23,10 @@ function Innhold(props: Props) {
 
             <BodyShort className={spacingStyles.blokkXs}>
                 Veilederne kan <strong>ikke</strong> svare på spørsmål om søknad om dagpenger, behandling av
-                dagpengesøknaden eller utbetaling av dagpenger.
+                dagpengesøknaden, utbetaling av dagpenger eller utfylling av meldekort.
             </BodyShort>
 
-            <BodyShort className={spacingStyles.blokkM}>
-                Dersom du lurer på noe om dagpenger ber vi deg bruke <SkrivTilOss /> eller <Chat />.
-            </BodyShort>
+            <STOogChat />
         </div>
     );
 }

--- a/src/komponenter/behovsavklaring-oppfolging/sto-og-chat.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/sto-og-chat.tsx
@@ -1,0 +1,82 @@
+import { BodyShort, Link } from '@navikt/ds-react';
+
+import { useAmplitudeData } from '../hent-initial-data/amplitude-provider';
+
+import { AmplitudeData } from '../../metrics/amplitude-utils';
+import { loggAktivitet } from '../../metrics/metrics';
+
+import spacingStyles from '../../spacing.module.css';
+
+interface Props {
+    amplitudeData: AmplitudeData;
+}
+
+function Innhold(props: Props) {
+    const { amplitudeData } = props;
+
+    function loggLenkeKlikk(handling: string, url: string) {
+        loggAktivitet({ ...amplitudeData, aktivitet: handling });
+        window.location.assign(url);
+    }
+
+    function SkrivTilOss() {
+        return (
+            <Link
+                href="https://mininnboks.nav.no/sporsmal/skriv/ARBD"
+                onClick={() =>
+                    loggLenkeKlikk('Går til STO fra behovsvurdering', 'https://mininnboks.nav.no/sporsmal/skriv/ARBD')
+                }
+            >
+                skriv til oss
+            </Link>
+        );
+    }
+
+    function Chat() {
+        return (
+            <Link
+                href="https://www.nav.no/person/kontakt-oss/chat/"
+                onClick={() =>
+                    loggLenkeKlikk('Går til Chat fra behovsvurdering', 'https://www.nav.no/person/kontakt-oss/chat/')
+                }
+            >
+                chat
+            </Link>
+        );
+    }
+
+    function Saksbehandlingstider() {
+        return (
+            <Link
+                href="https://www.nav.no/saksbehandlingstider#dagpenger"
+                onClick={() =>
+                    loggLenkeKlikk(
+                        'Går til saksbehandlingstider fra behovsvurdering',
+                        'https://www.nav.no/saksbehandlingstider#dagpenger'
+                    )
+                }
+            >
+                Saksbehandlingstider
+            </Link>
+        );
+    }
+
+    return (
+        <>
+            <BodyShort className={spacingStyles.mb1}>
+                Har du spørsmål om dagpenger eller meldekort må du bruke <SkrivTilOss /> eller <Chat />.
+            </BodyShort>
+            <BodyShort className={spacingStyles.mb1}>
+                <Saksbehandlingstider /> finner du en oversikt over på nav.no.
+            </BodyShort>
+        </>
+    );
+}
+
+function STOogChat() {
+    const { amplitudeData } = useAmplitudeData();
+
+    return <Innhold amplitudeData={amplitudeData} />;
+}
+
+export default STOogChat;

--- a/src/komponenter/hjelp-og-stotte/egenvurdering-uke12.tsx
+++ b/src/komponenter/hjelp-og-stotte/egenvurdering-uke12.tsx
@@ -18,7 +18,7 @@ const TEKSTER = {
         heading: 'Du har vært registrert i',
         uker: 'uker',
         beskrivelse:
-            'Har du fortsatt tro på at du greier å skaffe deg jobb på egenhånd, eller tenker du det er behov for hjelp og støtte fra en veileder ved NAV-kontoret ditt?',
+            'Har du fortsatt tro på at du greier å skaffe deg jobb på egen hånd, eller tenker du det er behov for hjelp og støtte fra en veileder ved NAV-kontoret ditt?',
         hjelp: 'Jeg ønsker hjelp',
         kss: 'Jeg klarer meg fint selv',
     },

--- a/src/komponenter/hjelp-og-stotte/forklaring-norsk.tsx
+++ b/src/komponenter/hjelp-og-stotte/forklaring-norsk.tsx
@@ -12,7 +12,7 @@ function Avsnitt1() {
     return (
         <div>
             <BodyShort className={spacingStyles.blokkXs}>
-                Vi tror at du har gode muligheter til å skaffe deg jobb på egenhånd.
+                Vi tror at du har gode muligheter til å skaffe deg jobb på egen hånd.
             </BodyShort>
 
             <BodyShort>Vår vurdering er basert på:</BodyShort>
@@ -50,7 +50,7 @@ function Avsnitt2() {
             <Heading size="xsmall">{harMottattBrev ? 'Du har mottatt et brev' : 'Du vil motta et brev'}</Heading>
             <BodyShort className={spacingStyles.blokkXs}>
                 {harMottattBrev ? <BrevLink /> : 'Brevet'} inneholder vår vurdering av dine muligheter til å skaffe deg
-                jobb på egenhånd.
+                jobb på egen hånd.
             </BodyShort>
             <BodyShort className={spacingStyles.blokkM}>
                 Dette brevet er ikke et svar på en eventuell søknad om dagpenger.


### PR DESCRIPTION
Tekstendringer og små endringer i grensesnittet for å forsøke en klarere flyt for arbeidssøkere som besvarer behovsvurderingen.

Ønsket er at:
1. større andel av de som blir profilert til standard innsats skal forstå hva det innebærer og at de er enige på "rett" grunnlag.
2. større andel av de som er uenige forteller hvilke behov de har i dialogen
