### PR TITLE
Bruker ny funksjonalitet i dialogen for behovsvurderingen

### DIFF
--- a/src/contexts/behov-for-veiledning.tsx
+++ b/src/contexts/behov-for-veiledning.tsx
@@ -8,7 +8,7 @@ export type BehovForVeiledningRequest = {
     oppfolging: ForeslattInnsatsgruppe;
     tekst?: string;
     overskrift?: string;
-    settTilFerdigBehandlet?: boolean;
+    venterPaaSvarFraNav?: boolean;
 };
 
 export type BehovForVeiledningResponse = {
@@ -30,20 +30,19 @@ export const BehovForVeiledningContext = createContext<BehovForVeiledningProvide
 async function opprettDialog(data: {
     tekst?: string;
     overskrift?: string;
-    settTilFerdigBehandlet?: boolean;
+    venterPaaSvarFraNav?: boolean;
 }): Promise<null | { id: string }> {
     if (!data.tekst && !data.overskrift) {
         return Promise.resolve(null);
     }
 
-    const dialogUrl = data.settTilFerdigBehandlet ? `${OPPRETT_DIALOG_URL}/egenvurdering` : OPPRETT_DIALOG_URL;
-
-    return fetchToJson(dialogUrl, {
+    return fetchToJson(OPPRETT_DIALOG_URL, {
         ...requestConfig(),
         method: 'POST',
         body: JSON.stringify({
             tekst: data.tekst,
             overskrift: data.overskrift,
+            venterPaaSvarFraNav: data.venterPaaSvarFraNav,
         }),
     });
 }

--- a/src/contexts/behov-for-veiledning.tsx
+++ b/src/contexts/behov-for-veiledning.tsx
@@ -8,6 +8,7 @@ export type BehovForVeiledningRequest = {
     oppfolging: ForeslattInnsatsgruppe;
     tekst?: string;
     overskrift?: string;
+    settTilFerdigBehandlet?: boolean;
 };
 
 export type BehovForVeiledningResponse = {
@@ -26,12 +27,18 @@ export const BehovForVeiledningContext = createContext<BehovForVeiledningProvide
     lagreBehovForVeiledning: () => Promise.resolve(),
 });
 
-async function opprettDialog(data: { tekst?: string; overskrift?: string }): Promise<null | { id: string }> {
+async function opprettDialog(data: {
+    tekst?: string;
+    overskrift?: string;
+    settTilFerdigBehandlet?: boolean;
+}): Promise<null | { id: string }> {
     if (!data.tekst && !data.overskrift) {
         return Promise.resolve(null);
     }
 
-    return fetchToJson(OPPRETT_DIALOG_URL, {
+    const dialogUrl = data.settTilFerdigBehandlet ? `${OPPRETT_DIALOG_URL}/egenvurdering` : OPPRETT_DIALOG_URL;
+
+    return fetchToJson(dialogUrl, {
         ...requestConfig(),
         method: 'POST',
         body: JSON.stringify({
@@ -40,6 +47,7 @@ async function opprettDialog(data: { tekst?: string; overskrift?: string }): Pro
         }),
     });
 }
+
 function BehovForVeiledningProvider(props: { children: ReactNode }) {
     const [behovForVeiledning, settBehovForVeiledning] = useState<BehovForVeiledningResponse>(null);
 

--- a/src/ducks/api.ts
+++ b/src/ducks/api.ts
@@ -26,7 +26,7 @@ export const requestConfig = (): RequestInit => {
         headers: {
             'Content-Type': 'application/json',
             NAV_CSRF_PROTECTION: getCookie('NAV_CSRF_PROTECTION'),
-            'NAV-Consumer-Id': 'veientilarbeid',
+            'Nav-Consumer-Id': 'veientilarbeid',
             'NAV-Call-Id': nanoid(),
         },
     };

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-ikke-svart-standard.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-ikke-svart-standard.tsx
@@ -67,7 +67,7 @@ function IkkeSvartPaaBehovsavklaringStandardInnsats() {
                 oppfolging: behov,
                 overskrift: tekst('behovOverskrift'),
                 tekst: dialogmelding,
-                settTilFerdigBehandlet: erStandard,
+                venterPaaSvarFraNav: !erStandard,
             });
             loggAktivitet({
                 ...amplitudeData,

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-ikke-svart-standard.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-ikke-svart-standard.tsx
@@ -50,14 +50,14 @@ function IkkeSvartPaaBehovsavklaringStandardInnsats() {
     const [pendingRequest, settPendingRequest] = useState<ForeslattInnsatsgruppe | null>(null);
 
     async function onClickBehovForVeiledning(behov: ForeslattInnsatsgruppe) {
+        const erStandard = behov === ForeslattInnsatsgruppe.STANDARD_INNSATS;
+
         // Dialogmeldingen skal gjenspeile svarene fra knappevalgene, endres det ene bør det andre også endres
         const dialogmelding =
             tekst('dialogtekstNavSinVurdering') +
             '\n\n' +
             tekst('dialogtekstMinVurdering') +
-            (behov === ForeslattInnsatsgruppe.STANDARD_INNSATS
-                ? tekst('dialogtekstSvarEnig')
-                : tekst('dialogtekstSvarUenig')) +
+            (erStandard ? tekst('dialogtekstSvarEnig') : tekst('dialogtekstSvarUenig')) +
             '.\n\n' +
             tekst('dialogtekstAutomatiskGenerert');
 
@@ -67,6 +67,7 @@ function IkkeSvartPaaBehovsavklaringStandardInnsats() {
                 oppfolging: behov,
                 overskrift: tekst('behovOverskrift'),
                 tekst: dialogmelding,
+                settTilFerdigBehandlet: erStandard,
             });
             loggAktivitet({
                 ...amplitudeData,


### PR DESCRIPTION
Vi ønsker at dialoger som genereres i kjølvannet av behovsvurderingen hvor arbeidssøkeren bekrefter at hen er enig i resultatet av profileringen ikke skal vises i arbeidslisten til veilederne.

Denne PRen tar i bruk ny funksjonalitet i dialoge og setter `venterPaaSvarFraNav: false` på disse meldingene.