### PR TITLE
Amplitudefelt for om url er minside eller underside

### DIFF
--- a/src/komponenter/hent-initial-data/amplitude-provider.tsx
+++ b/src/komponenter/hent-initial-data/amplitude-provider.tsx
@@ -58,6 +58,7 @@ export const initialAmplitudeData: AmplitudeData = {
     levertMeldekortEtterInaktvering: 'INGEN_DATA',
     automatiskReaktivert: 'INGEN_DATA',
     automatiskReaktivertSvar: 'INGEN_DATA',
+    loggetFraSide: 'INGEN_DATA',
 };
 
 const AmplitudeContext = createContext({
@@ -118,6 +119,9 @@ const AmplitudeProvider = (props: { children: React.ReactNode }) => {
     const valgtSprak = hentSprakValgFraCookie();
     const sprakValgFraCookie = valgtSprak || 'IKKE_VALGT';
 
+    const url = window.location.href;
+    const loggetFraSide = url.includes('arbeidssoker') ? 'Side 2' : 'Min side';
+
     const data: AmplitudeData = {
         ...initialAmplitudeData,
         brukergruppe: beregnBrukergruppe({
@@ -147,6 +151,7 @@ const AmplitudeProvider = (props: { children: React.ReactNode }) => {
         antallDagerSidenSisteArbeidssokerperiode,
         antallUkerSidenSisteArbeidssokerperiode,
         antallUkerMellomSisteArbeidssokerperioder,
+        loggetFraSide,
     };
 
     const [amplitudeData, setAmplitudeData] = React.useState(data);

--- a/src/metrics/amplitude-utils.ts
+++ b/src/metrics/amplitude-utils.ts
@@ -74,6 +74,7 @@ export type AmplitudeData = {
     levertMeldekortEtterInaktvering: 'INGEN_DATA' | 'Ja' | 'Nei';
     automatiskReaktivert: 'INGEN_DATA' | 'Ja';
     automatiskReaktivertSvar: 'INGEN_DATA' | 'Ikke svart' | 'ja' | 'nei';
+    loggetFraSide: 'Min side' | 'Side 2' | 'INGEN_DATA';
 };
 
 export function amplitudeLogger(name: string, values?: object) {


### PR DESCRIPTION
Min side-teamet jobber med å lage en ny inngang/boks på min side som lenker til AiA som en selvstendig underside. AiA ligger også inntil videre nederst på Min side i tillegg (alt dette ligger foreløpig bare i test). Legger derfor til en loggmelding som sjekker url og logger til amplitude om man er på "Min side" eller på "Side 2". 