### PR TITLE
Justering av padding og margin iht. min side retningslinjene

### DIFF
--- a/src/demo/demo-dashboard.tsx
+++ b/src/demo/demo-dashboard.tsx
@@ -348,9 +348,9 @@ const DemoDashboard = () => {
             <Heading size="xlarge" className={styles.demoHeading}>
                 Demo av Veien til arbeid
             </Heading>
-            <Box padding="4" className={styles.demodashboardInnhold}>
+            <Box className={`${styles.demodashboardInnhold} ${spacingStyles.pa125}`}>
                 <div className={`${spacingStyles.mb2} ${flexStyles.flex} ${flexStyles.wrap}`}>
-                    <Box padding="4" className={styles.demoCheckboxpanel}>
+                    <Box className={`${styles.demoCheckboxpanel} ${spacingStyles.pa125}`}>
                         <Select
                             label={'Velg arbeidssøkerperiode'}
                             onChange={handleChangeArbeidssokerPeriode}
@@ -439,7 +439,7 @@ const DemoDashboard = () => {
                             </Checkbox>
                         </CheckboxGroup>
                     </Box>
-                    <Box padding="4" className={styles.demoCheckboxpanel}>
+                    <Box className={`${styles.demoCheckboxpanel} ${spacingStyles.pa125}`}>
                         <Select
                             label={'Velg 14a vedtak'}
                             onChange={handleChangeServicegruppe}
@@ -465,7 +465,7 @@ const DemoDashboard = () => {
                             ))}
                         </Select>
 
-                        <Box padding="4" className={styles.demoCheckboxpanel}>
+                        <Box className={`${styles.demoCheckboxpanel} ${spacingStyles.pa125}`}>
                             <RadioGroup
                                 legend="Velg brukers valg"
                                 defaultValue={behovForVeiledningState?.oppfolging}
@@ -476,7 +476,7 @@ const DemoDashboard = () => {
                             </RadioGroup>
                         </Box>
 
-                        <Box padding="4" className={styles.demoCheckboxpanel}>
+                        <Box className={`${styles.demoCheckboxpanel} ${spacingStyles.pa125}`}>
                             <RadioGroup
                                 legend="Vil være arbeidssøker neste periode"
                                 defaultValue={hentDemoState(DemoData.ARBEIDSSOKER_NESTE_PERIODE) || 'Ja'}
@@ -487,7 +487,7 @@ const DemoDashboard = () => {
                             </RadioGroup>
                         </Box>
                     </Box>
-                    <Box padding="4" className={styles.demoFeaturetoggles}>
+                    <Box className={`${styles.demoFeaturetoggles} ${spacingStyles.pa125}`}>
                         <CheckboxGroup legend={'Featuretoggles'} value={getFeatureToggleCheckboxGroupValue()}>
                             {Object.values(FeatureToggles).map((toggle) => {
                                 return (
@@ -593,7 +593,7 @@ const DemoDashboard = () => {
                                     </Select>
                                 </Cell>
                                 <Cell xs={6} md={6} lg={3}>
-                                    <Box padding="4" className={styles.demoCheckboxpanel}>
+                                    <Box className={`${styles.demoCheckboxpanel} ${spacingStyles.pa125}`}>
                                         <CheckboxGroup
                                             legend=""
                                             value={[
@@ -644,7 +644,7 @@ const DemoDashboard = () => {
                                     </Box>
                                 </Cell>
                                 <Cell xs={6} md={6} lg={3}>
-                                    <Box padding="4" className={styles.demoFeaturetoggles}>
+                                    <Box className={`${styles.demoFeaturetoggles} ${spacingStyles.pa125}`}>
                                         <CheckboxGroup
                                             legend={'Featuretoggles'}
                                             value={getFeatureToggleCheckboxGroupValue()}

--- a/src/innhold/innhold.module.css
+++ b/src/innhold/innhold.module.css
@@ -23,6 +23,13 @@
     background-color: var(--a-surface-default);
     box-shadow: var(--a-shadow-xsmall);
     margin: 0;
+    padding: 1rem;
+}
+
+@media (min-width: 768px) {
+    .card {
+        padding: 1.25rem;
+    }
 }
 
 .header {

--- a/src/komponenter/aktivitetsplan/aktivitetsplan.tsx
+++ b/src/komponenter/aktivitetsplan/aktivitetsplan.tsx
@@ -1,6 +1,5 @@
 import { BodyLong, Heading, Link, Box } from '@navikt/ds-react';
 import { TasklistIcon } from '@navikt/aksel-icons';
-import spacingStyles from '../../spacing.module.css';
 import flexStyles from '../../flex.module.css';
 
 import { useSprakValg } from '../../contexts/sprak';
@@ -33,7 +32,7 @@ const Aktivitetsplan = () => {
     };
 
     return (
-        <Box padding="4" className={`${flexStyles.flex} ${spacingStyles.pb2}`}>
+        <Box className={flexStyles.flex}>
             <span
                 style={{
                     marginRight: '0.5em',

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-avklart-situasjonsbestemt.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-avklart-situasjonsbestemt.tsx
@@ -40,10 +40,10 @@ function BehovsavklaringAvklartSituasjonsbestemt() {
     const tekst = lagHentTekstForSprak(TEKSTER, sprak);
     const brukTabsDemo = useSkalBrukeTabs();
     return (
-        <Box padding="4">
+        <Box>
             <ErRendret loggTekst="Rendrer behovsavklaringkomponent - avklart - situasjonsbestemt" />
             {!brukTabsDemo && (
-                <Detail uppercase style={{ marginTop: '-1rem' }}>
+                <Detail uppercase className={spacingStyles.mt1}>
                     {tekst('overskrift')}
                 </Detail>
             )}

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-avklart-standard.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-avklart-standard.tsx
@@ -34,13 +34,9 @@ function BehovsavklaringAvklartStandard() {
     const skalVisesITabs = useSkalBrukeTabs();
 
     return (
-        <Box padding="4">
+        <Box>
             <ErRendret loggTekst="Rendrer behovsavklaringkomponent - avklart - standard" />
-            {!skalVisesITabs && (
-                <Detail uppercase style={{ marginTop: '-1rem' }}>
-                    {tekst('overskrift')}
-                </Detail>
-            )}
+            {!skalVisesITabs && <Detail uppercase>{tekst('overskrift')}</Detail>}
             <Heading className={spacingStyles.mb1} size="small">
                 {tekst('headingEnig')}
             </Heading>

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-ikke-svart-situasjonsbestemt.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-ikke-svart-situasjonsbestemt.tsx
@@ -65,10 +65,10 @@ function IkkeSvartPaaBehovsavklaringSituasjonsbestemt() {
     }
 
     return (
-        <Box padding="4">
+        <Box>
             <ErRendret loggTekst="Rendrer behovsavklaringkomponent - ikke svart - situasjonsbestemt" />{' '}
             {!brukTabsDemo && (
-                <Detail uppercase style={{ marginTop: '-1rem' }}>
+                <Detail uppercase className={spacingStyles.mt1}>
                     {tekst('overskrift')}
                 </Detail>
             )}

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-ikke-svart-standard.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-ikke-svart-standard.tsx
@@ -80,10 +80,10 @@ function IkkeSvartPaaBehovsavklaringStandardInnsats() {
     }
 
     return (
-        <Box padding="4">
+        <Box>
             <ErRendret loggTekst="Rendrer behovsavklaringkomponent - ikke svart - standard" />
             {!brukTabsDemo && (
-                <Detail uppercase style={{ marginTop: '-1rem' }}>
+                <Detail uppercase className={spacingStyles.mt1}>
                     {tekst('overskrift')}
                 </Detail>
             )}

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-svart-situasjonsbestemt.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-svart-situasjonsbestemt.tsx
@@ -41,7 +41,7 @@ function EnigMedProfilering() {
     const tekst = lagHentTekstForSprak(TEKSTER, sprak);
 
     return (
-        <Box padding="4">
+        <Box>
             <ErRendret loggTekst="Rendrer behovsavklaringkomponent - svart - enig - situasjonsbestemt" />
             <Heading size="small" className={spacingStyles.mb1}>
                 {tekst('headingEnig')}
@@ -66,7 +66,7 @@ function UenigMedProfilering() {
     const tekst = lagHentTekstForSprak(TEKSTER, sprak);
 
     return (
-        <Box padding="4">
+        <Box>
             <ErRendret loggTekst="Rendrer behovsavklaringkomponent - svart - uenig - situasjonsbestemt" />
             <Heading size="small" className={spacingStyles.mb1}>
                 {tekst('headingUenig')}

--- a/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-svart-standard.tsx
+++ b/src/komponenter/behovsavklaring-oppfolging/behovsavklaring-svart-standard.tsx
@@ -35,10 +35,10 @@ function EnigMedProfilering() {
     const brukTabsDemo = useSkalBrukeTabs();
 
     return (
-        <Box padding="4">
+        <Box>
             <ErRendret loggTekst="Rendrer behovsavklaringkomponent - svart - enig - standard" />
             {!brukTabsDemo && (
-                <Detail uppercase style={{ marginTop: '-1rem' }}>
+                <Detail uppercase className={spacingStyles.mt1}>
                     {tekst('overskrift')}
                 </Detail>
             )}
@@ -66,10 +66,10 @@ function UenigMedProfilering() {
     const tekst = lagHentTekstForSprak(TEKSTER, sprak);
     const brukTabsDemo = useSkalBrukeTabs();
     return (
-        <Box padding="4">
+        <Box>
             <ErRendret loggTekst="Rendrer behovsavklaringkomponent - svart - uenig - standard" />
             {!brukTabsDemo && (
-                <Detail uppercase style={{ marginTop: '-1rem' }}>
+                <Detail uppercase className={spacingStyles.mt1}>
                     {tekst('overskrift')}
                 </Detail>
             )}

--- a/src/komponenter/dagpenger/dagpenger-og-ytelser-innhold.tsx
+++ b/src/komponenter/dagpenger/dagpenger-og-ytelser-innhold.tsx
@@ -16,6 +16,7 @@ import Ytelser from './ytelser';
 import lagHentTekstForSprak from '../../lib/lag-hent-tekst-for-sprak';
 import useSkalBrukeTabs from '../../hooks/use-skal-bruke-tabs';
 import { useBeregnDagpengestatus } from '../../hooks/use-beregn-dagpengestatus';
+import spacingStyles from '../../spacing.module.css';
 
 function StansetDagpenger() {
     return <BodyShort>Stanset</BodyShort>;
@@ -62,9 +63,9 @@ function DagpengerOgYtelserInnhold(props: Props) {
     const tekst = lagHentTekstForSprak(TEKSTER, useSprakValg().sprak);
 
     return (
-        <Box padding="4">
+        <Box>
             {!brukTabsDemo && (
-                <Detail uppercase style={{ marginTop: '-1rem' }}>
+                <Detail uppercase className={spacingStyles.mt1}>
                     {tekst('tittel')}
                 </Detail>
             )}

--- a/src/komponenter/endre-situasjon/min-situasjon.tsx
+++ b/src/komponenter/endre-situasjon/min-situasjon.tsx
@@ -29,7 +29,7 @@ function MinSituasjon() {
     return (
         <Box>
             <ErRendret loggTekst="Rendrer endring av situasjon" />
-            <Box padding="4">
+            <Box>
                 {!skalVisesITabs && <Detail uppercase>Min situasjon</Detail>}
                 <Sammendrag
                     startDato={opprettetDato || aktivPeriodeStart}

--- a/src/komponenter/hjelp-og-stotte/hjelp-og-stotte.tsx
+++ b/src/komponenter/hjelp-og-stotte/hjelp-og-stotte.tsx
@@ -62,9 +62,9 @@ function HjelpOgStotte() {
     };
 
     return (
-        <Box padding="4">
+        <Box>
             {!brukTabsDemo && (
-                <Detail uppercase style={{ marginTop: '-1rem' }}>
+                <Detail uppercase className={spacingStyles.mt1}>
                     Hjelp og støtte
                 </Detail>
             )}

--- a/src/komponenter/ikke-registrert/ikke-registrert.tsx
+++ b/src/komponenter/ikke-registrert/ikke-registrert.tsx
@@ -1,4 +1,4 @@
-import { BodyShort, Box, Button, Heading } from '@navikt/ds-react';
+import { BodyShort, Button, Heading } from '@navikt/ds-react';
 import spacingStyles from '../../spacing.module.css';
 
 import { loggAktivitet } from '../../metrics/metrics';
@@ -47,7 +47,7 @@ const IkkeRegistrert = () => {
 
     return (
         <div className={styles.limitCenter}>
-            <Box className={spacingStyles.blokkS} ref={infoBoksRef} borderWidth="1">
+            <div className={styles.card} ref={infoBoksRef}>
                 <ErRendret loggTekst="Rendrer IkkeRegistrert" />
                 <Heading size="small" level="2" className={spacingStyles.blokkXs}>
                     {tekst('header')}
@@ -57,7 +57,7 @@ const IkkeRegistrert = () => {
                     {tekst('button')}
                 </Button>
                 <InViewport loggTekst="Viser IkkeRegistrert i viewport" />
-            </Box>
+            </div>
         </div>
     );
 };

--- a/src/komponenter/ikke-registrert/ikke-registrert.tsx
+++ b/src/komponenter/ikke-registrert/ikke-registrert.tsx
@@ -47,7 +47,7 @@ const IkkeRegistrert = () => {
 
     return (
         <div className={styles.limitCenter}>
-            <Box padding="4" className={spacingStyles.blokkS} ref={infoBoksRef} borderWidth="1">
+            <Box className={spacingStyles.blokkS} ref={infoBoksRef} borderWidth="1">
                 <ErRendret loggTekst="Rendrer IkkeRegistrert" />
                 <Heading size="small" level="2" className={spacingStyles.blokkXs}>
                     {tekst('header')}

--- a/src/komponenter/ikke-standard/forenklet-innhold.tsx
+++ b/src/komponenter/ikke-standard/forenklet-innhold.tsx
@@ -59,7 +59,7 @@ const TEKSTER = {
 
 const ListeElement = (ikon: JSX.Element, innhold: JSX.Element) => {
     return (
-        <li className={`${flexStyles.flex} ${spacingStyles.mb2}`}>
+        <li className={`${flexStyles.flex} ${spacingStyles.mb1}`}>
             <span
                 style={{
                     marginRight: '0.5em',
@@ -104,7 +104,7 @@ function ForenkletInnhold() {
     };
 
     return (
-        <Box padding="4" className={`${styles.mtn1} ${spacingStyles.mb1}`}>
+        <Box>
             <ul className={styles.ikkeStandardListe}>
                 {ListeElement(
                     <TasklistIcon aria-hidden="true" />,

--- a/src/komponenter/ikke-standard/ikke-standard.module.css
+++ b/src/komponenter/ikke-standard/ikke-standard.module.css
@@ -1,9 +1,13 @@
 .ikkeStandardListe {
     display: block;
     list-style-type: none;
-    margin-block-start: 1em;
-    margin-block-end: 1em;
-    margin-inline-start: 0px;
-    margin-inline-end: 0px;
-    padding-inline-start: 0px;
+    margin-block-start: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    margin-inline-end: 0;
+    padding-inline-start: 0;
+}
+
+.mtn1 {
+    margin-top: -1em;
 }

--- a/src/komponenter/ikke-standard/motestotte.tsx
+++ b/src/komponenter/ikke-standard/motestotte.tsx
@@ -108,7 +108,7 @@ const Motestotte = ({ state }: Props) => {
     if (!kanViseKomponent) return null;
 
     return (
-        <Box padding="4" className={spacingStyles.blokkS} borderWidth="1">
+        <Box className={spacingStyles.blokkS} borderWidth="1">
             <Heading size="small" level="1" className={spacingStyles.blokkXs}>
                 {tekst(`${sykmeldtStatus}-tittel`)}
             </Heading>

--- a/src/komponenter/meldekort/meldekort.tsx
+++ b/src/komponenter/meldekort/meldekort.tsx
@@ -12,6 +12,7 @@ import { loggAktivitet } from '../../metrics/metrics';
 import useSkalBrukeTabs from '../../hooks/use-skal-bruke-tabs';
 import { FeatureToggles, useFeatureToggleData } from '../../contexts/feature-toggles';
 import MeldekortMikrofrontend from '../meldekort-mikrofrontend/meldekort-mikrofrontend';
+import spacingStyles from '../../spacing.module.css';
 
 const TEKSTER = {
     nb: {
@@ -38,14 +39,14 @@ function Meldekort() {
     };
 
     return (
-        <Box padding="4">
+        <Box>
             {!brukTabsDemo && (
-                <Detail uppercase style={{ marginTop: '-1rem' }}>
+                <Detail uppercase className={spacingStyles.mt1}>
                     Meldekort og meldeplikt
                 </Detail>
             )}
             {brukMeldekortMikrofrontend ? <MeldekortMikrofrontend /> : <MeldekortHovedInnhold />}
-            <ReadMore size="small" header={tekst('overskrift')} onClick={handleClickLesMer}>
+            <ReadMore size="medium" header={tekst('overskrift')} onClick={handleClickLesMer}>
                 <MeldekortForklaring />
             </ReadMore>
         </Box>

--- a/src/komponenter/min-situasjon/min-situasjon.tsx
+++ b/src/komponenter/min-situasjon/min-situasjon.tsx
@@ -60,7 +60,7 @@ function MinSituasjon() {
         : 'Min jobbsituasjon: ukjent';
 
     return (
-        <Box padding="4">
+        <Box className={spacingStyles.mb1}>
             {!skalVisesITabs && <Detail uppercase>Min situasjon</Detail>}
             <Heading className={spacingStyles.mb1} size="small">
                 {heading}

--- a/src/komponenter/reaktivering/automatisk-reaktivert.tsx
+++ b/src/komponenter/reaktivering/automatisk-reaktivert.tsx
@@ -77,7 +77,7 @@ function AutomatiskReaktivert() {
     if (!kanViseKomponent) return null;
 
     return (
-        <Box padding="4" className={spacingStyles.pb1} ref={panelRef}>
+        <Box ref={panelRef}>
             <ErRendret loggTekst="Rendrer automatisk reaktivert" />
             {visSprakvelger && (
                 <Button variant="tertiary" size="xsmall" className={spacingStyles.ml1_75} onClick={toggleByttSprak}>

--- a/src/komponenter/reaktivering/reaktivering-kvittering.tsx
+++ b/src/komponenter/reaktivering/reaktivering-kvittering.tsx
@@ -86,7 +86,7 @@ const ReaktiveringKvittering = () => {
 
     return (
         <>
-            <Box padding="4" className={spacingStyles.mt1} style={{ background: 'var(--a-surface-warning-subtle)' }}>
+            <Box style={{ background: 'var(--a-surface-warning-subtle)' }}>
                 <div className={`${flexStyles.flex} ${flexStyles.spaceBetween} ${spacingStyles.blokkS}`}>
                     <div>
                         <Detail uppercase>{tekst('tittel')}</Detail>

--- a/src/komponenter/registrert-tittel/registrert-tittel.tsx
+++ b/src/komponenter/registrert-tittel/registrert-tittel.tsx
@@ -69,7 +69,7 @@ const RegistrertTittel = () => {
 
     return (
         <div ref={containerRef}>
-            <Box padding="4" className={`${spacingStyles.mb075} ${spacingStyles.pa0}`}>
+            <Box className={`${spacingStyles.mb075} ${spacingStyles.pa0}`}>
                 <BodyShort className={styles.header}>{tekst(hentTekstNokkel(erNyRegistrert, erPermittert))}</BodyShort>
             </Box>
         </div>

--- a/src/komponenter/situasjonsbestemt/situasjonsbestemt.module.css
+++ b/src/komponenter/situasjonsbestemt/situasjonsbestemt.module.css
@@ -1,11 +1,11 @@
 .ikkeStandardListe {
     display: block;
     list-style-type: none;
-    margin-block-start: 1em;
-    margin-block-end: 1em;
-    margin-inline-start: 0px;
-    margin-inline-end: 0px;
-    padding-inline-start: 0px;
+    margin-block-start: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    margin-inline-end: 0;
+    padding-inline-start: 0;
 }
 
 .mtn1 {

--- a/src/komponenter/situasjonsbestemt/situasjonsbestemt.tsx
+++ b/src/komponenter/situasjonsbestemt/situasjonsbestemt.tsx
@@ -63,7 +63,7 @@ const TEKSTER = {
 
 export const ListeElement = (ikon: JSX.Element, innhold: JSX.Element) => {
     return (
-        <li className={`${flexStyles.flex} ${spacingStyles.mb2}`}>
+        <li className={`${flexStyles.flex} ${spacingStyles.mb1}`}>
             <span
                 style={{
                     marginRight: '0.5em',
@@ -128,7 +128,7 @@ function Situasjonsbestemt() {
     };
 
     return (
-        <Box padding="4" className={`${styles.mtn1} ${spacingStyles.mb1}`}>
+        <Box className={`${styles.mtn1} ${spacingStyles.mb1}`}>
             <ul className={styles.ikkeStandardListe}>
                 {harGyldigBehovsvurdering ? <DialogPanel /> : <Behovsavklaring />}
                 {harGyldigBehovsvurdering &&

--- a/src/spacing.module.css
+++ b/src/spacing.module.css
@@ -1,3 +1,6 @@
+@import "@navikt/ds-tokens";
+
+/* margins */
 .mr05 {
     margin-right: 0.5rem!important;
 }
@@ -66,8 +69,33 @@
     margin-bottom: 0!important;
 }
 
+.blokkXs {
+    margin-bottom: 1rem!important;
+}
+
+.blokkS {
+    margin-bottom: 20px!important;
+}
+
+.blokkM {
+    margin-bottom: 2rem!important;
+}
+
+/* padding */
+
 .pa1 {
     padding: 1rem!important;
+}
+
+/* pa125 følger retningslinjene for spacing fra min side */
+.pa125 {
+    padding: var(--a-spacing-4)!important;
+}
+
+@media (min-width: 768px) {
+    .pa125 {
+        padding: var(--a-spacing-5)!important;
+    }
 }
 
 .pa0 {
@@ -95,18 +123,7 @@
     padding-bottom: 2rem!important;
 }
 
-.blokkXs {
-    margin-bottom: 1rem!important;
-}
-
-.blokkS {
-    margin-bottom: 20px!important;
-}
-
-.blokkM {
-    margin-bottom: 2rem!important;
-}
-
+/* bredde */
 .fullWidth {
     width: 100%;
 }

--- a/src/tabs/aia-tabs.tsx
+++ b/src/tabs/aia-tabs.tsx
@@ -26,6 +26,7 @@ import {
 
 import tabStyles from './tabs.module.css';
 import styles from '../innhold/innhold.module.css';
+import spacingStyles from '../spacing.module.css';
 import {
     harSendtInnNyDokumentasjon,
     harSitasjonSomKreverDokumentasjon,
@@ -50,7 +51,7 @@ const tabValueMap = {
 
 const MinSituasjonTab = () => {
     return (
-        <Tabs.Panel value="situasjon">
+        <Tabs.Panel value="situasjon" className={spacingStyles.pa125}>
             <MinSituasjon />
         </Tabs.Panel>
     );
@@ -58,7 +59,7 @@ const MinSituasjonTab = () => {
 
 const HjelpOgStotteTab = () => {
     return (
-        <Tabs.Panel value="hjelp">
+        <Tabs.Panel value="hjelp" className={spacingStyles.pa125}>
             <Behovsavklaring />
         </Tabs.Panel>
     );
@@ -66,7 +67,7 @@ const HjelpOgStotteTab = () => {
 
 const YtelseTab = () => {
     return (
-        <Tabs.Panel value="ytelse">
+        <Tabs.Panel value="ytelse" className={spacingStyles.pa125}>
             <DagpengerOgYtelser />
         </Tabs.Panel>
     );
@@ -74,7 +75,7 @@ const YtelseTab = () => {
 
 const MeldekortTab = () => {
     return (
-        <Tabs.Panel value="meldekort">
+        <Tabs.Panel value="meldekort" className={spacingStyles.pa125}>
             <Meldekort />
         </Tabs.Panel>
     );
@@ -165,7 +166,7 @@ const AiaTabs = () => {
         <div className={styles.limitStandard}>
             <RegistrertTittel />
             <div className={styles.card}>
-                <Tabs value={aktivTab} onChange={onChangeTab} className={tabStyles.mt1}>
+                <Tabs value={aktivTab} onChange={onChangeTab} className={tabStyles.man125}>
                     <Tabs.List>
                         <Tabs.Tab
                             value="situasjon"

--- a/src/tabs/tabs.module.css
+++ b/src/tabs/tabs.module.css
@@ -10,6 +10,16 @@
     margin-left: -2.4rem !important;
 }
 
+.man125 {
+    margin: -1rem!important;
+}
+
+@media (min-width: 768px) {
+    .man125 {
+        margin: -1.25rem!important;
+    }
+}
+
 .nowrap {
     white-space: nowrap;
 }


### PR DESCRIPTION
Skrevet om fra bruk av padding 4 på box (Panel ble brukt tidligere men er nå deprecated til fordel for Box) til å bruke padding 1 rem på mobil og 1.25 rem på desktop.
Design tokens for breakpoints lar seg ikke bruke i form av css variabler i media queries, så det er grunnen til hardcodet min-width: 768px.

Endret generell bruk av padding og margin til å være mer konsistent gjennomgående.
Spacing følger nå retningslinjene gitt av min side her: https://aksel.nav.no/god-praksis/artikler/retningslinjer-for-design-av-mikrofrontends?tema=design