### PR TITLE
Dev/oppdatert tekst om dp automatisk reaktivert

### DIFF
--- a/src/komponenter/reaktivering/automatisk-reaktivert.tsx
+++ b/src/komponenter/reaktivering/automatisk-reaktivert.tsx
@@ -95,6 +95,13 @@ function AutomatiskReaktivert() {
                         {prettyPrintDato(reaktivering.opprettetDato, valgtSprak)} {tekst('meldekortInnsendt')}
                     </BodyLong>
                     <BodyLong className={spacingStyles.mb1}>{tekst('derfor')}</BodyLong>
+                    <Heading size="small" level="3">
+                        Hva med dagpengene mine?
+                    </Heading>
+                    <BodyLong spacing>
+                        Har du mottatt dagpenger vil utbetalingene nå være stoppet. Du må sende inn ny søknad om
+                        dagpenger.
+                    </BodyLong>
                     <ReadMoreInaktivering sprak={valgtSprak} />
                     <ReadMoreViktigRegistrert sprak={valgtSprak} />
                     <div className={`${spacingStyles.mt1} ${flexStyles.flex} ${flexStyles.flexColumn}`}>

--- a/src/komponenter/reaktivering/readmore-viktig-registrert.tsx
+++ b/src/komponenter/reaktivering/readmore-viktig-registrert.tsx
@@ -14,7 +14,7 @@ const TEKSTER = {
         header: 'Hvorfor er det viktig at jeg er registrert som arbeidssøker?',
         ytelser:
             'Noen av ytelsene fra NAV, for eksempel dagpenger og tiltakspenger, kan du bare motta hvis du er registrert som arbeidssøker.',
-        oppfolging: 'NAV ønsker også at de som skal motta arbeidsrettet oppfølging er regisrert som arbeidssøker.',
+        oppfolging: 'NAV ønsker også at de som skal motta arbeidsrettet oppfølging er registrert som arbeidssøker.',
         soknad: 'Du må være registrert som arbeidssøker fra du sender inn søknad om ytelse og helt frem til den siste dagen du ønsker å motta pengestøtten. Det er kun de dagene du er registrert som arbeidssøker du kan få utbetalt ytelse for.',
     },
     en: {

--- a/src/standard-wrapper.tsx
+++ b/src/standard-wrapper.tsx
@@ -1,13 +1,34 @@
-import flex from './flex.module.css';
+import { useFeatureToggleData } from './contexts/feature-toggles';
+import { useReaktivering } from './contexts/reaktivering';
+
 import AiaTabs from './tabs/aia-tabs';
 import InnholdStandard from './innhold/innhold-standard';
 import { useWindowInnerWidth } from './contexts/window-inner-width';
 import { MIN_TABS_BREDDE } from './hooks/use-skal-bruke-tabs';
+import { visAutomatiskReaktiveringsKort } from './lib/vis-automatisk-reaktiverings-kort';
+import { AutomatiskReaktivert } from './komponenter/reaktivering/automatisk-reaktivert';
+
+import flex from './flex.module.css';
+import styles from './innhold/innhold.module.css';
 
 function StandardWrapper() {
     const { innerWidth } = useWindowInnerWidth();
+    const featuretoggleData = useFeatureToggleData();
+    const { reaktivering } = useReaktivering();
 
     const brukTabs = innerWidth > MIN_TABS_BREDDE;
+
+    const skalViseReaktiveringsKort = visAutomatiskReaktiveringsKort(featuretoggleData, reaktivering);
+
+    if (skalViseReaktiveringsKort) {
+        return (
+            <div className={styles.limitStandard}>
+                <div className={`${styles.limitCenter} ${styles.card}`}>
+                    <AutomatiskReaktivert />
+                </div>
+            </div>
+        );
+    }
 
     return <div className={`${flex.flex} ${flex.center}`}>{brukTabs ? <AiaTabs /> : <InnholdStandard />}</div>;
 }


### PR DESCRIPTION
Legger til tekst om at dagpenger er stoppet på meldingen som vises etter automatisk reaktivering.

Sikrer at meldingen etter automatisk reaktivering også vises for de som har tabs-utgaven av grensesnittet.